### PR TITLE
Disable the torchaudio warnings in pyannote and torch_audiomentations

### DIFF
--- a/verbatim/__main__.py
+++ b/verbatim/__main__.py
@@ -2,10 +2,14 @@ import argparse
 import os
 import sys
 import logging
+import warnings
 import torch
 from .__init__ import __version__
 from .pipeline import Pipeline
 from .context import Context
+
+warnings.filterwarnings("ignore", category=UserWarning, module=r"pyannote\.audio\.core\.io")
+warnings.filterwarnings("ignore", category=UserWarning, module=r"torch_audiomentations\.utils\.io")
 
 LOG = logging.getLogger(__name__)
 

--- a/verbatim/__main__.py
+++ b/verbatim/__main__.py
@@ -8,7 +8,11 @@ from .__init__ import __version__
 from .pipeline import Pipeline
 from .context import Context
 
+
+# see https://github.com/pyannote/pyannote-audio/issues/1576
 warnings.filterwarnings("ignore", category=UserWarning, module=r"pyannote\.audio\.core\.io")
+
+# see https://github.com/asteroid-team/torch-audiomentations/issues/172
 warnings.filterwarnings("ignore", category=UserWarning, module=r"torch_audiomentations\.utils\.io")
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
Addresses the warnings reported here: https://github.com/gaspardpetit/verbatim/issues/11#issuecomment-1891461101

This will mute the warnings until changes from the following are integrated:
- https://github.com/pyannote/pyannote-audio/issues/1576
- https://github.com/asteroid-team/torch-audiomentations/issues/172
