### PR TITLE
Improve language detection with fallback

### DIFF
--- a/verbatim/verbatim.py
+++ b/verbatim/verbatim.py
@@ -307,9 +307,9 @@ class Verbatim:
                 )
             if prob > 0.5 or lang_samples_size == available_samples:
                 break
-            else:
-                # retry with larger sample
-                lang_samples_size = min(2 * lang_samples_size, available_samples)
+            # retry with larger sample
+            lang_samples_size = min(2 * lang_samples_size, available_samples)
+
         return lang
 
     def transcribe_window(self) -> Tuple[List[VerbatimWord], List[VerbatimWord]]:

--- a/verbatim/voices/transcribe/faster_whisper.py
+++ b/verbatim/voices/transcribe/faster_whisper.py
@@ -39,10 +39,11 @@ class FasterWhisperTranscriber(Transcriber):
         guess_prob = 0
         for l in lang:
             for t in all_language_probs:
-                if t[0] == l and t[1] > guess_prob:
-                    guess_lang = t[0]
-                    guess_prob = t[1]
-                    LOG.info(f"detected '{lang}' with probability {guess_prob}")
+                if t[0] == l:
+                    if t[1] > guess_prob:
+                        guess_lang = t[0]
+                        guess_prob = t[1]
+                        LOG.info(f"detected '{l}' with probability {guess_prob}")
         return guess_lang, guess_prob
 
 


### PR DESCRIPTION
When language cannot be detected accurately with only 2 seconds of audio, fallback to 4, 8 and 16 seconds