### PR TITLE
feat: add HTTP transcription server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Save file in a specific directory
 verbatim audio_file.mp3 -o ./output/
 ```
 
+Start an HTTP server
+```bash
+verbatim --serve
+```
+This exposes a local `/audio/transcriptions` endpoint compatible with OpenAI's API.
+Include `-F stream=true` in your request to receive Server-Sent Events (`transcript.text.delta`, `transcript.text.done`).
+
 For see the [detailed terminal documentation](doc/verbatim-cli.md) for additional examples and options.
 
 ## Usage (from Docker)

--- a/doc/verbatim-cli.md
+++ b/doc/verbatim-cli.md
@@ -56,6 +56,10 @@ If no input file is provided, Verbatim expects input from stdin or can use the m
 - `-v, --verbose`: Increase verbosity (use multiple times for more detail)
 - `-i, --isolate`: Extract voices from background noise
 
+#### Server
+- `--serve`: Start an HTTP server with an OpenAI-compatible `/audio/transcriptions` endpoint
+  - Use `-F stream=true` in your request to receive Server-Sent Events
+
 #### Version & Help
 - `--version`: Display the version and exit
 - `-h, --help`: Show help message and exit

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,44 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+import aiohttp
+from aiohttp.test_utils import TestClient, TestServer
+
+from verbatim.config import Config
+from verbatim.server import create_app
+
+
+class ServerEndpointTests(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        config = Config(device="cpu", output_dir=".", working_dir=".", stream=False, offline=True)
+        app = create_app(config)
+        self.server = TestServer(app)
+        self.client = TestClient(self.server)
+        await self.client.start_server()
+
+    async def asyncTearDown(self):
+        await self.client.close()
+
+    @patch("verbatim.server.transcribe_file", return_value="hello world")
+    async def test_transcriptions_endpoint(self, mock_transcribe):
+        data = aiohttp.FormData()
+        data.add_field("file", b"abc", filename="a.wav", content_type="audio/wav")
+        resp = await self.client.post("/audio/transcriptions", data=data)
+        self.assertEqual(resp.status, 200)
+        payload = await resp.json()
+        self.assertEqual(payload["text"], "hello world")
+        mock_transcribe.assert_called()
+
+    @patch("verbatim.server.iterate_transcription", return_value=iter(["hi ", "there"]))
+    async def test_transcriptions_stream_endpoint(self, mock_iter):
+        data = aiohttp.FormData()
+        data.add_field("file", b"abc", filename="a.wav", content_type="audio/wav")
+        data.add_field("stream", "true")
+        resp = await self.client.post("/audio/transcriptions", data=data)
+        self.assertEqual(resp.status, 200)
+        body = await resp.text()
+        self.assertIn("transcript.text.delta", body)
+        self.assertIn("hi ", body)
+        self.assertIn("there", body)
+        self.assertIn("transcript.text.done", body)
+        mock_iter.assert_called()

--- a/verbatim/main.py
+++ b/verbatim/main.py
@@ -78,6 +78,7 @@ def main():
         action="store_true",
         help="Prefetch commonly used models into the cache and exit",
     )
+    parser.add_argument("--serve", action="store_true", help="Start an HTTP server with an OpenAI-compatible endpoint")
     parser.add_argument(
         "-w",
         "--workdir",
@@ -170,6 +171,8 @@ def main():
         model_cache_dir=args.model_cache,
     )
 
+    config.lang = args.languages if args.languages else ["en"]
+
     # Handle install-only mode
     if args.install:
         LOG.info("Installing/prefetching models into cache...")
@@ -179,12 +182,16 @@ def main():
         LOG.info("Model prefetch complete.")
         return
 
+    if args.serve:
+        from .server import serve
+
+        serve(config)
+        return
+
     source_path = args.input
     input_name_no_ext = os.path.splitext(os.path.split(source_path)[-1])[0]
     output_prefix_no_ext = os.path.join(config.output_dir, input_name_no_ext)
     working_prefix_no_ext = os.path.join(config.working_dir, input_name_no_ext)
-
-    config.lang = args.languages if args.languages else ["en"]
 
     # Set output formats
     from .transcript.format.writer import TranscriptWriterConfig

--- a/verbatim/server.py
+++ b/verbatim/server.py
@@ -1,0 +1,123 @@
+import asyncio
+import json
+import os
+import tempfile
+import threading
+from dataclasses import replace
+from typing import Iterable, Optional, cast
+
+from aiohttp import web
+from aiohttp.multipart import BodyPartReader
+
+from .audio.sources.factory import create_audio_source
+from .audio.sources.sourceconfig import SourceConfig
+from .config import Config
+from .verbatim import Verbatim
+
+
+async def _handle_transcriptions(request: web.Request) -> web.StreamResponse:
+    config: Config = request.app["config"]
+    reader = await request.multipart()
+    file_path: Optional[str] = None
+    language: Optional[str] = None
+    stream = False
+
+    async for raw_part in reader:
+        part = cast(BodyPartReader, raw_part)
+        if part.name == "file":
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                while chunk := await part.read_chunk():
+                    tmp.write(chunk)
+                file_path = tmp.name
+        elif part.name == "language":
+            language = await part.text()
+        elif part.name == "stream":
+            stream = (await part.text()).lower() == "true"
+
+    if file_path is None:
+        return web.json_response({"error": "file is required"}, status=400)
+
+    if not stream:
+        try:
+            text = await asyncio.to_thread(transcribe_file, file_path, config, language)
+        finally:
+            os.unlink(file_path)
+        return web.json_response({"text": text})
+
+    # streaming response
+    resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+    await resp.prepare(request)
+
+    loop = asyncio.get_event_loop()
+    queue: asyncio.Queue[Optional[str]] = asyncio.Queue()
+
+    def worker() -> None:
+        try:
+            for piece in iterate_transcription(file_path, config, language):
+                asyncio.run_coroutine_threadsafe(queue.put(piece), loop)
+        finally:
+            asyncio.run_coroutine_threadsafe(queue.put(None), loop)
+            os.unlink(file_path)
+
+    threading.Thread(target=worker, daemon=True).start()
+
+    pieces: list[str] = []
+    while True:
+        piece = await queue.get()
+        if piece is None:
+            break
+        pieces.append(piece)
+        await resp.write(
+            f"data: {json.dumps({'type': 'transcript.text.delta', 'delta': piece})}\n\n".encode()
+        )
+
+    final_text = "".join(pieces).strip()
+    await resp.write(
+        f"data: {json.dumps({'type': 'transcript.text.done', 'text': final_text})}\n\n".encode()
+    )
+    await resp.write_eof()
+    return resp
+
+
+def iterate_transcription(
+    path: str, base_config: Config, language: Optional[str] = None
+) -> Iterable[str]:
+    cfg = replace(base_config)
+    if language:
+        cfg.lang = [language]
+    basename = os.path.splitext(os.path.basename(path))[0]
+    working_prefix = os.path.join(cfg.working_dir, basename)
+    output_prefix = os.path.join(cfg.output_dir, basename)
+    source_config = SourceConfig()
+    audio_source = create_audio_source(
+        source_config=source_config,
+        device=cfg.device,
+        input_source=path,
+        start_time="00:00.000",
+        stop_time="",
+        working_prefix_no_ext=working_prefix,
+        output_prefix_no_ext=output_prefix,
+        stream=cfg.stream,
+    )
+    transcriber = Verbatim(cfg)
+    with audio_source.open() as audio_stream:
+        for utterance, _, _ in transcriber.transcribe(
+            audio_stream=audio_stream, working_prefix_no_ext=working_prefix
+        ):
+            yield utterance.text
+
+
+def transcribe_file(path: str, base_config: Config, language: Optional[str] = None) -> str:
+    return "".join(iterate_transcription(path, base_config, language)).strip()
+
+
+def create_app(config: Config) -> web.Application:
+    app = web.Application()
+    app["config"] = config
+    app.router.add_post("/audio/transcriptions", _handle_transcriptions)
+    return app
+
+
+def serve(config: Config, host: str = "0.0.0.0", port: int = 8000) -> None:
+    app = create_app(config)
+    web.run_app(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- add streaming support to `/audio/transcriptions` via Server-Sent Events when `stream=true`
- document streaming usage in README and CLI reference
- test streaming endpoint behavior

## Testing
- `make check` *(fails: Pylint invalid-name in verbatim/_version.py)*
- `ruff check verbatim tests`
- `flake8 verbatim tests`
- `pylint --disable=import-error,invalid-name verbatim $(git ls-files 'tests/*.py')`
- `pyright`
- `bandit -r verbatim tests run.py` *(1 medium issue: binding to all interfaces)*
- `python -m unittest discover -s tests -q` *(fails: ModuleNotFoundError: scipy, pyannote, pywhispercpp, colorama)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b65d91a0832cb55425c7a7fe45c0