### PR TITLE
fix: avoid labeling silent stereo segments

### DIFF
--- a/tests/test_stereo_diarization.py
+++ b/tests/test_stereo_diarization.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+# pylint: disable=import-outside-toplevel
+
+
+class TestStereoDiarization(unittest.TestCase):
+    def test_determine_speaker_silence(self):
+        from verbatim.voices.diarize.stereo import StereoDiarization
+
+        diarizer = StereoDiarization()
+        speaker = diarizer._determine_speaker(0.0, 0.0, 0.0, 0.0)
+        self.assertEqual(speaker, "UNKNOWN")
+
+    def test_compute_diarization_silence(self):
+        import soundfile as sf
+
+        from verbatim.voices.diarize.stereo import StereoDiarization
+
+        sample_rate = 16000
+        audio = np.zeros((sample_rate, 2), dtype=np.float32)
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            sf.write(tmp.name, audio, sample_rate)
+            tmp_path = tmp.name
+
+        try:
+            diarizer = StereoDiarization()
+            annotation = diarizer.compute_diarization(tmp_path, segment_duration=0.5)
+            self.assertEqual(len(annotation), 0)
+        finally:
+            os.remove(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verbatim/voices/diarize/stereo.py
+++ b/verbatim/voices/diarize/stereo.py
@@ -28,6 +28,11 @@ class StereoDiarization(DiarizationStrategy):
         return energy_left, energy_right, peak_left, peak_right
 
     def _determine_speaker(self, energy_left: float, energy_right: float, peak_left: float, peak_right: float) -> str:
+        # If both channels carry effectively no energy, treat as silence
+        epsilon = 1e-8
+        if energy_left <= epsilon and energy_right <= epsilon:
+            return "UNKNOWN"
+
         # Calculate energy ratios
         left_to_right_ratio = energy_left / energy_right if energy_right > 0 else float("inf")
         right_to_left_ratio = energy_right / energy_left if energy_left > 0 else float("inf")


### PR DESCRIPTION
## Summary
- handle silent stereo segments in `_determine_speaker` to avoid spurious diarization
- add regression tests for silent stereo diarization

## Testing
- `ruff check --exclude verbatim/_version.py verbatim tests`
- `flake8 verbatim tests --count`
- `pylint --disable=import-error,invalid-name verbatim $(git ls-files 'tests/*.py')`
- `pyright`
- `bandit -r verbatim tests run.py`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ext/samples/audio'; OSError: Can't load tokenizer for 'facebookAI/xlm-roberta-base')*

------
https://chatgpt.com/codex/tasks/task_e_68b51db7efb4832c8971ad004518edeb