### PR TITLE
fix: defer heavy server imports

### DIFF
--- a/verbatim/server.py
+++ b/verbatim/server.py
@@ -9,10 +9,7 @@ from typing import Iterable, Optional, Union, cast
 from aiohttp import web
 from aiohttp.multipart import BodyPartReader
 
-from .audio.sources.factory import create_audio_source
-from .audio.sources.sourceconfig import SourceConfig
 from .config import Config
-from .verbatim import Verbatim
 
 
 async def _handle_transcriptions(request: web.Request) -> web.StreamResponse:
@@ -96,6 +93,10 @@ async def _handle_transcriptions(request: web.Request) -> web.StreamResponse:
 def iterate_transcription(
     path: str, base_config: Config, language: Optional[str] = None
 ) -> Iterable[str]:
+    from .audio.sources.factory import create_audio_source  # pylint: disable=import-outside-toplevel
+    from .audio.sources.sourceconfig import SourceConfig  # pylint: disable=import-outside-toplevel
+    from .verbatim import Verbatim  # pylint: disable=import-outside-toplevel
+
     cfg = replace(base_config)
     if language:
         cfg.lang = [language]


### PR DESCRIPTION
## Summary
- defer heavy server imports to runtime to avoid model downloads

## Testing
- `ruff check verbatim tests`
- `flake8 verbatim tests`
- `pylint --disable=import-error verbatim/server.py tests/test_server.py`
- `pyright`
- `bandit -r verbatim tests run.py`
- `pytest tests/test_server.py -q`
- `pytest -q` *(fails: Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and outgoing traffic has been disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68b5450f189c832cbbc7ec82bfcddaee