### PR TITLE
fix: restore audio settings module for reload

### DIFF
--- a/verbatim/audio/settings.py
+++ b/verbatim/audio/settings.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import sys
+import types
 from dataclasses import dataclass
 
 
@@ -37,3 +39,16 @@ def get_audio_params() -> AudioParams:
 
 
 AUDIO_PARAMS = get_audio_params()
+
+
+class _SettingsModule(types.ModuleType):
+    """Ensure module is present in :data:`sys.modules` when accessed."""
+
+    def __getattribute__(self, name: str):  # pragma: no cover - trivial
+        mod_name = object.__getattribute__(self, "__name__")
+        if sys.modules.get(mod_name) is not self:
+            sys.modules[mod_name] = self
+        return super().__getattribute__(name)
+
+
+sys.modules[__name__].__class__ = _SettingsModule


### PR DESCRIPTION
## Summary
- ensure audio settings module reinstalls itself into `sys.modules`
- allow `importlib.reload` after tests remove cached modules

## Testing
- `pytest tests/test_audio_settings.py tests/test_window.py -q`
- `pytest -q -m "not slow and not requires_hf"` *(fails: Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and outgoing traffic has been disabled. To enable repo look-ups and downloads online, pass 'local_files_only=False' as input.)*
- `ruff check verbatim tests`
- `flake8 verbatim tests`
- `pylint --disable=import-error verbatim $(git ls-files 'tests/*.py')`
- `pyright`
- `bandit -r verbatim tests run.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bbdb16c0832c9a18948bc7811a36