### PR TITLE
refactor: allow custom transcription hooks

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,5 @@
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import aiohttp
 from aiohttp.test_utils import TestClient, TestServer
@@ -19,21 +19,23 @@ class ServerEndpointTests(IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         await self.client.close()
 
-    @patch("verbatim.server.transcribe_file", return_value="hello world")
-    async def test_transcriptions_endpoint(self, mock_transcribe):
+    async def test_transcriptions_endpoint(self):
         data = aiohttp.FormData()
         data.add_field("file", b"abc", filename="a.wav", content_type="audio/wav")
+        mock_transcribe = MagicMock(return_value="hello world")
+        self.server.app["transcribe_func"] = mock_transcribe
         resp = await self.client.post("/audio/transcriptions", data=data)
         self.assertEqual(resp.status, 200)
         payload = await resp.json()
         self.assertEqual(payload["text"], "hello world")
         mock_transcribe.assert_called()
 
-    @patch("verbatim.server.iterate_transcription", return_value=iter(["hi ", "there"]))
-    async def test_transcriptions_stream_endpoint(self, mock_iter):
+    async def test_transcriptions_stream_endpoint(self):
         data = aiohttp.FormData()
         data.add_field("file", b"abc", filename="a.wav", content_type="audio/wav")
         data.add_field("stream", "true")
+        mock_iter = MagicMock(return_value=iter(["hi ", "there"]))
+        self.server.app["transcribe_iter"] = mock_iter
         resp = await self.client.post("/audio/transcriptions", data=data)
         self.assertEqual(resp.status, 200)
         body = await resp.text()
@@ -43,11 +45,12 @@ class ServerEndpointTests(IsolatedAsyncioTestCase):
         self.assertIn("transcript.text.done", body)
         mock_iter.assert_called()
 
-    @patch("verbatim.server.iterate_transcription", side_effect=RuntimeError("boom"))
-    async def test_transcriptions_stream_endpoint_error(self, mock_iter):
+    async def test_transcriptions_stream_endpoint_error(self):
         data = aiohttp.FormData()
         data.add_field("file", b"abc", filename="a.wav", content_type="audio/wav")
         data.add_field("stream", "true")
+        mock_iter = MagicMock(side_effect=RuntimeError("boom"))
+        self.server.app["transcribe_iter"] = mock_iter
         resp = await self.client.post("/audio/transcriptions", data=data)
         self.assertEqual(resp.status, 200)
         body = await resp.text()


### PR DESCRIPTION
## Summary
- Allow server handlers to pull transcription functions from the app so they can be swapped in tests
- Support dependency injection in `create_app` via optional `transcribe_func` and `transcribe_iter` parameters
- Inject mocks directly into the server app in tests to avoid global state interference

## Testing
- `pytest tests/test_server.py -q`
- `pytest -q -m "not slow and not requires_hf"` *(fails: LocalEntryNotFoundError in tests/test_pipeline.py)*
- `ruff check verbatim tests --exclude verbatim/_version.py`
- `flake8 verbatim tests`
- `pylint --disable=import-error,invalid-name verbatim $(git ls-files 'tests/*.py')`
- `pyright` *(warning: Import "termcolor" could not be resolved)*
- `bandit -r verbatim tests run.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa21dc10832c9b1b5b8e1164c5e9