### PR TITLE
Decouple pyannote and VAD

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -100,10 +100,6 @@ recursive=no
 # source root.
 source-roots=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,9 +62,7 @@ class ServerEndpointTests(IsolatedAsyncioTestCase):
         resp = await self.client.get("/models")
         self.assertEqual(resp.status, 200)
         payload = await resp.json()
-        self.assertTrue(
-            any(m["id"] == "whisper-large-v3-verbatim" for m in payload["data"])
-        )
+        self.assertTrue(any(m["id"] == "whisper-large-v3-verbatim" for m in payload["data"]))
 
         resp = await self.client.get("/models/whisper-large-v3-verbatim")
         self.assertEqual(resp.status, 200)

--- a/verbatim/audio/sources/audiosource.py
+++ b/verbatim/audio/sources/audiosource.py
@@ -1,8 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from numpy.typing import NDArray
-from pyannote.core.annotation import Annotation
+
+if TYPE_CHECKING:
+    from pyannote.core.annotation import Annotation
+else:  # pragma: no cover - type-only fallback to avoid runtime dependency
+    Annotation = object  # pylint: disable=invalid-name
 
 
 class AudioStream(ABC):

--- a/verbatim/audio/sources/factory.py
+++ b/verbatim/audio/sources/factory.py
@@ -1,16 +1,20 @@
 import errno
 import os
 import sys
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
-from pyannote.core.annotation import Annotation
 
 from ...voices.diarize.factory import create_diarizer  # Add this import
 from ..audio import samples_to_seconds, timestr_to_samples
 from ..convert import convert_to_wav
 from .audiosource import AudioSource
 from .sourceconfig import SourceConfig
+
+if TYPE_CHECKING:
+    from pyannote.core.annotation import Annotation
+else:  # pragma: no cover - type-only fallback to avoid runtime dependency
+    Annotation = Any  # pylint: disable=invalid-name
 
 
 def compute_diarization(
@@ -32,6 +36,7 @@ def compute_diarization(
 
         PyAnnote Annotation object
     """
+
     diarizer = create_diarizer(strategy=strategy, device=device, huggingface_token=os.getenv("HUGGINGFACE_TOKEN"))
 
     return diarizer.compute_diarization(file_path=file_path, out_rttm_file=rttm_file, nb_speakers=nb_speakers)

--- a/verbatim/audio/sources/fileaudiosource.py
+++ b/verbatim/audio/sources/fileaudiosource.py
@@ -1,16 +1,20 @@
 import logging
 import os
 import wave
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
-from pyannote.core.annotation import Annotation
 
 from ...voices.isolation import VoiceIsolation
 from ..audio import format_audio, sample_to_timestr
 from ..convert import convert_to_wav
 from .audiosource import AudioSource, AudioStream
+
+if TYPE_CHECKING:
+    from pyannote.core.annotation import Annotation
+else:  # pragma: no cover - type-only fallback to avoid runtime dependency
+    Annotation = object  # pylint: disable=invalid-name
 
 LOG = logging.getLogger(__name__)
 

--- a/verbatim/audio/sources/sourceconfig.py
+++ b/verbatim/audio/sources/sourceconfig.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from pyannote.core.annotation import Annotation
+if TYPE_CHECKING:
+    from pyannote.core.annotation import Annotation
+else:  # pragma: no cover - type-only fallback to avoid runtime dependency
+    Annotation = object  # pylint: disable=invalid-name
 
 
 @dataclass

--- a/verbatim/server.py
+++ b/verbatim/server.py
@@ -71,28 +71,20 @@ async def _handle_transcriptions(request: web.Request) -> web.StreamResponse:
             break
         if isinstance(item, Exception):
             error = item
-            await resp.write(
-                f"data: {json.dumps({'type': 'error', 'error': str(item)})}\n\n".encode()
-            )
+            await resp.write(f"data: {json.dumps({'type': 'error', 'error': str(item)})}\n\n".encode())
             break
         piece = cast(str, item)
         pieces.append(piece)
-        await resp.write(
-            f"data: {json.dumps({'type': 'transcript.text.delta', 'delta': piece})}\n\n".encode()
-        )
+        await resp.write(f"data: {json.dumps({'type': 'transcript.text.delta', 'delta': piece})}\n\n".encode())
 
     if error is None:
         final_text = "".join(pieces).strip()
-        await resp.write(
-            f"data: {json.dumps({'type': 'transcript.text.done', 'text': final_text})}\n\n".encode()
-        )
+        await resp.write(f"data: {json.dumps({'type': 'transcript.text.done', 'text': final_text})}\n\n".encode())
     await resp.write_eof()
     return resp
 
 
-def iterate_transcription(
-    path: str, base_config: Config, language: Optional[str] = None
-) -> Iterable[str]:
+def iterate_transcription(path: str, base_config: Config, language: Optional[str] = None) -> Iterable[str]:
     from .audio.sources.factory import create_audio_source  # pylint: disable=import-outside-toplevel
     from .audio.sources.sourceconfig import SourceConfig  # pylint: disable=import-outside-toplevel
     from .verbatim import Verbatim  # pylint: disable=import-outside-toplevel
@@ -116,9 +108,7 @@ def iterate_transcription(
     )
     transcriber = Verbatim(cfg)
     with audio_source.open() as audio_stream:
-        for utterance, _, _ in transcriber.transcribe(
-            audio_stream=audio_stream, working_prefix_no_ext=working_prefix
-        ):
+        for utterance, _, _ in transcriber.transcribe(audio_stream=audio_stream, working_prefix_no_ext=working_prefix):
             yield utterance.text
 
 


### PR DESCRIPTION
This pull request makes several improvements to type handling and code clarity, especially around the use of the `pyannote.core.annotation.Annotation` type. It introduces type-only imports to avoid runtime dependencies on `pyannote`, refactors type hints accordingly, and improves the flexibility of the VAD (Voice Activity Detection) callback in the `Verbatim` class. There are also minor formatting changes for code readability.

### Type handling and dependency management

* Replaced direct imports of `Annotation` from `pyannote.core.annotation` with guarded type-only imports using `TYPE_CHECKING` in multiple files (`verbatim/audio/sources/audiosource.py`, `verbatim/audio/sources/factory.py`, `verbatim/audio/sources/fileaudiosource.py`, `verbatim/audio/sources/sourceconfig.py`, `verbatim/verbatim.py`). This avoids runtime dependency issues when `pyannote` is not installed. [[1]](diffhunk://#diff-3ab4ea91345a1f867b209a8df9b5227d753e93dfd333a5cbba952f31c4f4cea1L2-R9) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L4-R18) [[3]](diffhunk://#diff-07b5ce05887be6d3332080fcd4d13083038261bff1c060f331ebdd5445f04807L4-R18) [[4]](diffhunk://#diff-298434e026812bd9bed044edbbb7082dbef243ea1634beb6bec36c59668b253aL2-R7) [[5]](diffhunk://#diff-b7494eb15ea120709b0d58d6f8115844db95caa7a4a2f9882ea37523b253f4c6L9-L14) [[6]](diffhunk://#diff-b7494eb15ea120709b0d58d6f8115844db95caa7a4a2f9882ea37523b253f4c6R43-R48)

### Voice Activity Detection (VAD) improvements

* Refactored the `Verbatim` class to accept an optional `vad_callback` parameter for VAD, defaulting to the existing Silero VAD if not provided, and updated silence detection logic to use this callback. This enables easier injection of alternative VAD implementations.

### Code formatting and readability

* Reformatted several lines in `tests/test_server.py` and `verbatim/server.py` to reduce line length and improve readability, without changing functionality. [[1]](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acL65-R65) [[2]](diffhunk://#diff-ec547413ede060d66fe4b3023df47c35ddee60144bd6510d9550e96d77ab5e3eL74-R87) [[3]](diffhunk://#diff-ec547413ede060d66fe4b3023df47c35ddee60144bd6510d9550e96d77ab5e3eL119-R111)
* Minor whitespace and formatting changes in `verbatim/audio/sources/factory.py` for consistency.

### Configuration changes

* Removed the `suggestion-mode=yes` setting from `.pylintrc`, possibly to reduce noise from pylint's suggestion hints.