### PR TITLE
Added verbatim_rttm for lightweight rttm handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "openai>=1.59.8",
     "datasets>=3.2.0",
     "python-dotenv>=1.0.1",
+    "pyyaml>=6.0.2",
     "termcolor>=3.1.0",
 ]
 
@@ -100,7 +101,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
-include = ["verbatim/**/*", "verbatim_core/**/*"]
+include = ["verbatim/**/*", "verbatim_core/**/*", "verbatim_rttm/**/*"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/tests/test_rttm.py
+++ b/tests/test_rttm.py
@@ -1,0 +1,72 @@
+import os
+import tempfile
+import unittest
+
+from verbatim_rttm import (
+    Annotation,
+    AudioRef,
+    Segment,
+    load_rttm,
+    load_vttm,
+    loads_rttm,
+    write_rttm,
+    write_vttm,
+)
+
+
+class TestRTTM(unittest.TestCase):
+    def test_rttm_roundtrip_file(self):
+        segments = [
+            Segment(start=0.0, end=1.5, speaker="S1", file_id="sample", channel="1"),
+            Segment(start=1.5, end=3.0, speaker="S2", file_id="sample", channel="1"),
+        ]
+        annotation = Annotation(segments=segments)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sample.rttm")
+            write_rttm(annotation, path)
+            parsed = load_rttm(path)
+
+        self.assertEqual(len(parsed.segments), 2)
+        self.assertEqual(parsed.segments[0].speaker, "S1")
+        self.assertEqual(parsed.segments[1].speaker, "S2")
+        self.assertAlmostEqual(parsed.segments[0].start, 0.0)
+        self.assertAlmostEqual(parsed.segments[1].end, 3.0)
+
+    def test_loads_rttm_from_string(self):
+        rttm_text = "\n".join(
+            [
+                "SPEAKER sample 1 0.000 1.000 <NA> <NA> SPK0 <NA> <NA>",
+                "SPEAKER sample 1 1.000 1.000 <NA> <NA> SPK1 0.9 <NA>",
+            ]
+        )
+        annotation = loads_rttm(rttm_text)
+        self.assertEqual(len(annotation.segments), 2)
+        self.assertEqual(annotation.segments[0].speaker, "SPK0")
+        self.assertIsNone(annotation.segments[0].confidence)
+        self.assertAlmostEqual(annotation.segments[1].confidence or 0, 0.9, places=3)
+
+
+class TestVTTM(unittest.TestCase):
+    def test_vttm_roundtrip(self):
+        annotation = Annotation(
+            segments=[
+                Segment(start=0.0, end=2.0, speaker="A", file_id="audio1"),
+            ]
+        )
+        audio_refs = [AudioRef(id="audio1", path="/data/audio1.wav", channel="1")]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sample.vttm")
+            write_vttm(path, audio=audio_refs, annotation=annotation)
+            loaded_audio, loaded_annotation = load_vttm(path)
+
+        self.assertEqual(len(loaded_audio), 1)
+        self.assertEqual(loaded_audio[0].id, "audio1")
+        self.assertEqual(loaded_audio[0].path, "/data/audio1.wav")
+        self.assertEqual(len(loaded_annotation.segments), 1)
+        self.assertEqual(loaded_annotation.segments[0].speaker, "A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verbatim/voices/diarization.py
+++ b/verbatim/voices/diarization.py
@@ -2,8 +2,7 @@ import logging
 import os
 from typing import Optional
 
-from pyannote.core.annotation import Annotation
-from pyannote.database.util import load_rttm
+from verbatim_rttm import Annotation, load_rttm
 
 from .diarize.factory import create_diarizer
 
@@ -31,12 +30,9 @@ class Diarization:
         if not os.path.exists(rttm_file):
             raise FileNotFoundError(f"RTTM file not found: {rttm_file}")
 
-        rttms = load_rttm(file_rttm=rttm_file)
-
-        if not rttms:
+        annotation: Annotation = load_rttm(rttm_file)
+        if len(annotation) == 0:
             raise ValueError(f"No diarization data found in RTTM file: {rttm_file}")
-
-        annotation: Annotation = next(iter(rttms.values()))
         return annotation
 
     def compute_diarization(self, file_path: str, out_rttm_file: Optional[str] = None, strategy: str = "pyannote", **kwargs) -> Annotation:

--- a/verbatim_rttm/__init__.py
+++ b/verbatim_rttm/__init__.py
@@ -1,0 +1,6 @@
+"""Lightweight RTTM reader/writer aligned to the NIST Rich Transcription specification."""
+
+from .rttm import Annotation, Segment, load_rttm, loads_rttm, write_rttm
+from .vttm import AudioRef, load_vttm, write_vttm
+
+__all__ = ["Annotation", "Segment", "load_rttm", "loads_rttm", "write_rttm", "AudioRef", "load_vttm", "write_vttm"]

--- a/verbatim_rttm/rttm.py
+++ b/verbatim_rttm/rttm.py
@@ -1,0 +1,124 @@
+import dataclasses
+from io import StringIO
+from typing import IO, Iterable, Iterator, List, Optional, Tuple
+
+
+@dataclasses.dataclass(order=True)
+class Segment:
+    """Simple diarization segment."""
+
+    start: float
+    end: float
+    speaker: str
+    file_id: str = ""
+    channel: str = "1"
+    orthography: str = "<NA>"
+    subtype: str = "<NA>"
+    confidence: Optional[float] = None
+    slat: Optional[float] = None
+
+    @property
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+class Annotation:
+    """Minimal Annotation for RTTM interoperability (NIST Rich Transcription)."""
+
+    def __init__(self, segments: Optional[Iterable[Segment]] = None, file_id: str | None = None):
+        self.file_id = file_id
+        self._segments: List[Segment] = sorted(list(segments) if segments else [], key=lambda s: (s.start, s.end))
+
+    def __len__(self) -> int:
+        return len(self._segments)
+
+    def itertracks(self, *, yield_label: bool = False) -> Iterator[Tuple[Segment, None, str]]:
+        """Yield segments in start order, mimicking common diarization iterators."""
+        for segment in sorted(self._segments, key=lambda s: (s.start, s.end)):
+            yield (segment, None, segment.speaker) if yield_label else (segment, None, None)  # type: ignore
+
+    def write_rttm(self, fp) -> None:
+        """Write to an RTTM file-like object."""
+        for line in _serialize_segments(self._segments):
+            fp.write(line)
+
+    def add(self, segment: Segment) -> None:
+        self._segments.append(segment)
+        self._segments.sort(key=lambda s: (s.start, s.end))
+
+    @property
+    def segments(self) -> List[Segment]:
+        return list(self._segments)
+
+
+def _parse_float(value: str) -> Optional[float]:
+    if value in ("<NA>", "NA", ""):
+        return None
+    return float(value)
+
+
+def _parse_segment(parts: List[str]) -> Segment:
+    if len(parts) < 8:
+        raise ValueError(f"Malformed RTTM line (expected >= 8 fields): {' '.join(parts)}")
+
+    _, file_id, channel, start, duration, orthography, subtype, speaker, *rest = parts
+    confidence = _parse_float(rest[0]) if len(rest) > 0 else None
+    slat = _parse_float(rest[1]) if len(rest) > 1 else None
+
+    return Segment(
+        start=float(start),
+        end=float(start) + float(duration),
+        speaker=speaker if speaker != "<NA>" else "unknown",
+        file_id=file_id,
+        channel=channel,
+        orthography=orthography,
+        subtype=subtype,
+        confidence=confidence,
+        slat=slat,
+    )
+
+
+def load_rttm(path: str) -> Annotation:
+    """Parse RTTM file into an Annotation (NIST RTTM format)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return _load_rttm_lines(fh)
+
+
+def loads_rttm(text: str) -> Annotation:
+    """Parse RTTM content provided as a string (NIST RTTM format)."""
+    return _load_rttm_lines(StringIO(text))
+
+
+def _load_rttm_lines(lines: Iterable[str]) -> Annotation:
+    segments: List[Segment] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        parts = line.split()
+        if parts[0].upper() != "SPEAKER":
+            continue  # ignore non-speaker records for now
+        segment = _parse_segment(parts)
+        segments.append(segment)
+    file_id = segments[0].file_id if segments else None
+    return Annotation(segments=segments, file_id=file_id)
+
+
+def _serialize_segments(segments: Iterable[Segment]) -> Iterator[str]:
+    for seg in sorted(segments, key=lambda s: (s.start, s.end)):
+        conf = f"{seg.confidence:.3f}" if seg.confidence is not None else "<NA>"
+        slat = f"{seg.slat:.3f}" if seg.slat is not None else "<NA>"
+        yield (
+            f"SPEAKER {seg.file_id} {seg.channel} {seg.start:.3f} {seg.duration:.3f} {seg.orthography} {seg.subtype} {seg.speaker} {conf} {slat}\n"
+        )
+
+
+def write_rttm(annotation: Annotation, dest: str | IO[str]) -> None:
+    """Write an Annotation to an RTTM file or file-like object."""
+    if isinstance(dest, str):
+        with open(dest, "w", encoding="utf-8") as fh:
+            for line in _serialize_segments(annotation.segments):
+                fh.write(line)
+    else:
+        for line in _serialize_segments(annotation.segments):
+            dest.write(line)

--- a/verbatim_rttm/vttm.py
+++ b/verbatim_rttm/vttm.py
@@ -1,0 +1,84 @@
+"""
+VTTM: YAML-wrapped RTTM for self-contained diarization + audio references.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
+
+from .rttm import Annotation, Segment, loads_rttm, write_rttm
+
+
+@dataclass
+class AudioRef:
+    """Reference to an audio asset used by the RTTM diarization."""
+
+    id: str
+    path: str
+    channel: str | int = "1"
+
+
+def load_vttm(path: str) -> Tuple[List[AudioRef], Annotation]:
+    """Load a VTTM (YAML with embedded RTTM) file."""
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("PyYAML is required to load VTTM files. Install pyyaml.") from exc
+
+    with open(path, "r", encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh) or {}
+
+    audio_entries = _parse_audio(doc.get("audio"))
+    rttm_raw = doc.get("rttm", "")
+    rttm_text = "\n".join(rttm_raw) if isinstance(rttm_raw, list) else str(rttm_raw)
+    annotation = loads_rttm(rttm_text)
+    return audio_entries, annotation
+
+
+def write_vttm(path: str, *, audio: Iterable[AudioRef], annotation: Annotation) -> None:
+    """Write a VTTM file with audio references and embedded RTTM."""
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise ImportError("PyYAML is required to write VTTM files. Install pyyaml.") from exc
+
+    rttm_lines = []
+    for line in _serialize_annotation(annotation):
+        rttm_lines.append(line.rstrip("\n"))
+
+    payload = {
+        "audio": [{"id": ref.id, "path": ref.path, "channel": ref.channel} for ref in audio],
+        "rttm": "\n".join(rttm_lines) + ("\n" if rttm_lines else ""),
+    }
+
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=False)
+
+
+def _parse_audio(raw_audio) -> List[AudioRef]:
+    if raw_audio is None:
+        return []
+    if isinstance(raw_audio, dict):
+        raw_audio = [raw_audio]
+    audio_refs: List[AudioRef] = []
+    for entry in raw_audio:
+        if not isinstance(entry, dict):
+            continue
+        audio_id = entry.get("id") or entry.get("file") or entry.get("name")
+        path = entry.get("path") or entry.get("file_path")
+        if not audio_id or not path:
+            continue
+        channel = entry.get("channel", "1")
+        audio_refs.append(AudioRef(id=str(audio_id), path=str(path), channel=str(channel)))
+    return audio_refs
+
+
+def _serialize_annotation(annotation: Annotation):
+    """Yield RTTM lines from an Annotation."""
+    # Reuse write_rttm logic via an in-memory buffer
+    import io
+
+    buffer = io.StringIO()
+    write_rttm(annotation, buffer)  # type: ignore[arg-type]
+    buffer.seek(0)
+    for line in buffer:
+        yield line


### PR DESCRIPTION
This pull request introduces a new lightweight RTTM and VTTM reader/writer package (`verbatim_rttm`) aligned with the NIST Rich Transcription specification, and refactors diarization code to use it. It also adds new tests, updates dependencies, and ensures proper packaging of the new module.

**New RTTM/VTTM functionality:**

* Added `verbatim_rttm` package with minimal RTTM support, including `Annotation`, `Segment`, and functions to read/write RTTM files and strings (`rttm.py`). Also added VTTM support for YAML-wrapped RTTM with audio references (`vttm.py`). [[1]](diffhunk://#diff-713e04a50b9d8327a3bbca0b591ed9346135a1e7edbf6f9078615c14146b2fedR1-R124) [[2]](diffhunk://#diff-2782e8445d8418276bd3d45682db0d5c24b057e3ae6fd1cb6de88b86e9e0eabaR1-R84) [[3]](diffhunk://#diff-69a3f64890562bd5fba9aeadd64c00fd826ecca6080b619ea10938e07e5470d2R1-R6)
* Added comprehensive unit tests for RTTM and VTTM roundtrips to `tests/test_rttm.py`.

**Refactoring and integration:**

* Refactored `verbatim/voices/diarization.py` to use the new `verbatim_rttm` package for RTTM parsing, replacing the previous dependency on `pyannote`. Improved error handling and streamlined RTTM loading logic. [[1]](diffhunk://#diff-bd3f9e2777049ec368306bdd601e227009b3cb2141c5d6f618faa98aff5e94d8L5-R5) [[2]](diffhunk://#diff-bd3f9e2777049ec368306bdd601e227009b3cb2141c5d6f618faa98aff5e94d8L34-L39)

**Packaging and dependency updates:**

* Updated `pyproject.toml` to include `pyyaml` as a dependency (required for VTTM), and to package the new `verbatim_rttm` module. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R77) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L103-R104)