### PR TITLE
output vttm instead of rttm from diarization

### DIFF
--- a/verbatim/audio/sources/sourceconfig.py
+++ b/verbatim/audio/sources/sourceconfig.py
@@ -14,3 +14,4 @@ class SourceConfig:
     diarization: Optional[Annotation] = None
     diarization_file: Optional[str] = None
     diarization_strategy: str = "pyannote"
+    vttm_file: Optional[str] = None

--- a/verbatim_diarization/separate/base.py
+++ b/verbatim_diarization/separate/base.py
@@ -24,6 +24,7 @@ class SeparationStrategy(ABC):
         *,
         file_path: str,
         out_rttm_file: Optional[str] = None,
+        out_vttm_file: Optional[str] = None,
         out_speaker_wav_prefix="",
         nb_speakers: Optional[int] = None,
         start_sample: int = 0,


### PR DESCRIPTION
This pull request adds support for handling VTTM diarization files alongside existing RTTM files throughout the audio source and diarization pipeline. The changes ensure that both file formats are properly generated, loaded, and passed between components, improving compatibility and flexibility for diarization workflows.

**VTTM file support and integration:**

* Added VTTM file handling to the `SourceConfig` class and all relevant functions, allowing configuration and propagation of VTTM file paths (`sourceconfig.py`, `factory.py`). [[1]](diffhunk://#diff-298434e026812bd9bed044edbbb7082dbef243ea1634beb6bec36c59668b253aR17) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R27) [[3]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R86-R89)
* Updated diarization and separation strategies (`pyannote`, `stereo`) to generate VTTM files in addition to RTTM files, including logic for segment and audio reference creation and file writing (`pyannote/diarize.py`, `pyannote/separate.py`, `stereo/diarize.py`, `stereo/separate.py`). [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7R62-R71) [[2]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcR164-R182) [[3]](diffhunk://#diff-2f5724a8669fc95814d7f4b0c9ccada8b829c595bf90379f2a9d4d4fd927aeafL100-R110) [[4]](diffhunk://#diff-d6155ae657f17c5b3b38778eb7074e34739d8caba7ee576882d30792c6f5cc4fL77-R98)
* Modified pipeline to load diarization from VTTM files when available, with fallback to RTTM if needed (`factory.py`). [[1]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L121-R143) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R155-R163)

**Function and API updates:**

* Extended function signatures for diarization and separation to accept `out_vttm_file` parameters, ensuring VTTM file paths are passed and handled throughout the codebase (`factory.py`, `pyannote/diarize.py`, `pyannote/separate.py`, `stereo/diarize.py`, `stereo/separate.py`, `separate/base.py`). [[1]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L44-R46) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L197-R219) [[3]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R272) [[4]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7L26-R31) [[5]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcR67) [[6]](diffhunk://#diff-486d6cc2be29b590e5437b5df2cd0e192e436a4b76ea27b4aa1a15986e84b1aaR27) [[7]](diffhunk://#diff-2f5724a8669fc95814d7f4b0c9ccada8b829c595bf90379f2a9d4d4fd927aeafL54-R54) [[8]](diffhunk://#diff-d6155ae657f17c5b3b38778eb7074e34739d8caba7ee576882d30792c6f5cc4fR28)

**Implementation details and improvements:**

* Ensured correct directory creation for output files, robust error handling, and consistent annotation and audio reference construction for VTTM writing (`pyannote/diarize.py`, `stereo/diarize.py`, `pyannote/separate.py`, `stereo/separate.py`). [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7R62-R71) [[2]](diffhunk://#diff-2f5724a8669fc95814d7f4b0c9ccada8b829c595bf90379f2a9d4d4fd927aeafL100-R110) [[3]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcR164-R182) [[4]](diffhunk://#diff-d6155ae657f17c5b3b38778eb7074e34739d8caba7ee576882d30792c6f5cc4fL77-R98)
* Updated logic in audio source creation to set default VTTM file paths and handle empty or missing values gracefully (`factory.py`).

These changes collectively enable the system to support both RTTM and VTTM diarization formats, improving interoperability and future-proofing diarization workflows.