### PR TITLE
Support vttm input

### DIFF
--- a/verbatim/audio/sources/sourceconfig.py
+++ b/verbatim/audio/sources/sourceconfig.py
@@ -12,6 +12,6 @@ class SourceConfig:
     isolate: Optional[bool] = None
     diarize: Optional[int] = None
     diarization: Optional[Annotation] = None
-    diarization_file: Optional[str] = None
+    diarization_file: Optional[str] = None  # legacy RTTM; when set, we derive from vttm
     diarization_strategy: str = "pyannote"
     vttm_file: Optional[str] = None

--- a/verbatim/main.py
+++ b/verbatim/main.py
@@ -39,12 +39,19 @@ def main():
     parser.add_argument("-o", "--outdir", default=".", help="Path to the output directory")
     parser.add_argument("--diarization-strategy", choices=["pyannote", "stereo"], default="pyannote", help="Diarization strategy to use")
     parser.add_argument(
+        "--vttm",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="Path to VTTM diarization file to use; if omitted, a minimal VTTM will be created (and filled if diarization runs).",
+    )
+    parser.add_argument(
         "-d",
         "--diarization",
         nargs="?",
         action=OptionalValueAction,
         default=None,
-        help="Identify speakers in transcript using the diarization RTTM file at the specified path (ex. diarization.rttm)",
+        help="(Deprecated) RTTM diarization file path; if provided, it will be wrapped into a VTTM and consumed.",
     )
     parser.add_argument(
         "--separate", nargs="?", action=OptionalValueAction, default=None, help="Enables speaker voice separation and process each speaker separately"


### PR DESCRIPTION
This pull request introduces improvements to how VTTM diarization files are handled in the audio source creation process. The changes ensure that a minimal VTTM placeholder is generated when needed, streamline the logic for loading diarization data, and update the command-line interface to support VTTM files directly. The most important changes are grouped below:

**VTTM File Handling Improvements:**

* Automatically creates a minimal VTTM placeholder file if none is provided, ensuring downstream processes have a valid file to work with.
* Updates logic to always set `vttm_file` to a default path when not specified, both for regular and separate speaker source creation. [[1]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L86-R90) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R265-R268)
* Writes diarization results into the VTTM file after loading from RTTM, keeping VTTM and RTTM files in sync.

**Diarization Loading Robustness:**

* Refines the logic for loading diarization from VTTM: handles missing or invalid files gracefully and avoids redundant RTTM loading when VTTM is present.

**Command-line Interface Updates:**

* Adds a new `--vttm` argument to the CLI, allowing users to specify a VTTM file directly; updates help text to clarify the relationship between VTTM and RTTM files.
* Updates comments in `SourceConfig` to clarify the legacy status of RTTM files and their derivation from VTTM.

**General Codebase Enhancements:**

* Adds a module-level logger for improved diagnostics and debugging.
* Refactors imports to support new VTTM handling logic.