### PR TITLE
Make vttm first class instead of rttm

### DIFF
--- a/verbatim/audio/sources/factory.py
+++ b/verbatim/audio/sources/factory.py
@@ -157,7 +157,8 @@ def create_audio_source(
                 source_config.diarization = Diarization.load_diarization(rttm_file=source_config.diarization_file)
                 if source_config.vttm_file and source_config.diarization is not None:
                     audio_id = os.path.splitext(os.path.basename(input_source))[0]
-                    write_vttm(source_config.vttm_file, audio=[AudioRef(id=audio_id, path=input_source)], annotation=source_config.diarization)  # type: ignore[arg-type]
+                    # Derive VTTM from RTTM for compatibility
+                    write_vttm(source_config.vttm_file, audio=[AudioRef(id=audio_id, path=input_source)], annotation=source_config.diarization)
             except (StopIteration, FileNotFoundError):
                 # If the file doesn't exist or is empty, compute new diarization
                 source_config.diarization = compute_diarization(

--- a/verbatim_diarization/diarize/base.py
+++ b/verbatim_diarization/diarize/base.py
@@ -11,17 +11,20 @@ class DiarizationStrategy(ABC):
     """Base class for all diarization strategies"""
 
     @abstractmethod
-    def compute_diarization(self, file_path: str, out_rttm_file: Optional[str] = None, **kwargs) -> Annotation:
+    def compute_diarization(
+        self, file_path: str, out_rttm_file: Optional[str] = None, out_vttm_file: Optional[str] = None, **kwargs
+    ) -> Annotation:
         """
         Compute speaker diarization for the given audio file.
 
         Args:
             file_path: Path to the audio file
-            out_rttm_file: Optional path to output RTTM file
+            out_rttm_file: Optional legacy RTTM output path (derived from VTTM if present)
+            out_vttm_file: Preferred VTTM output path
             **kwargs: Strategy-specific parameters
 
         Returns:
-            PyAnnote Annotation object containing speaker segments
+            Annotation object containing speaker segments
         """
 
     def save_rttm(self, annotation: Annotation, out_rttm_file: str):

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -75,7 +75,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
 
         Args:
             file_path: Path to input audio file
-            out_rttm_file: Path to output RTTM file
+            out_rttm_file: Optional legacy RTTM output path
             out_speaker_wav_prefix: Prefix for output WAV files
             nb_speakers: Optional number of speakers
 
@@ -85,7 +85,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
         separated_sources: List[AudioSource] = []
         diarization_annotation = None
         if not out_rttm_file:
-            out_rttm_file = "out.rttm"
+            out_rttm_file = None
 
         # For stereo strategy, we might want to handle separation differently
         if self.diarization_strategy == "stereo":
@@ -134,9 +134,10 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             # pyannote.audio 4.x returns DiarizeOutput; normalize to Annotation
             diarization = diarization_output.speaker_diarization if hasattr(diarization_output, "speaker_diarization") else diarization_output
 
-            # Save diarization to RTTM file
-            with open(out_rttm_file, "w", encoding="utf-8") as rttm:
-                diarization.write_rttm(rttm)
+            # Save diarization to RTTM file if requested
+            if out_rttm_file:
+                with open(out_rttm_file, "w", encoding="utf-8") as rttm:
+                    diarization.write_rttm(rttm)
             diarization_annotation = diarization
 
             # Save separated sources to WAV files

--- a/verbatim_diarization/stereo/separate.py
+++ b/verbatim_diarization/stereo/separate.py
@@ -36,7 +36,7 @@ class ChannelSeparation(SeparationStrategy):
 
         Args:
             file_path: Path to input audio file.
-            out_rttm_file: Path to output RTTM file.
+            out_rttm_file: Optional legacy RTTM output path.
             out_speaker_wav_prefix: Prefix for output WAV files.
             nb_speakers: Optional number of speakers (ignored for this implementation).
 


### PR DESCRIPTION
This pull request introduces improvements to how speaker diarization output files are handled, with a focus on supporting both legacy RTTM and preferred VTTM formats. The changes clarify output file options, update documentation, and ensure compatibility between formats. The most important changes are grouped below:

**Diarization Output Format Support**

* The `DiarizationStrategy.compute_diarization` method signature now supports both `out_rttm_file` (legacy RTTM) and `out_vttm_file` (preferred VTTM) as output options, with updated documentation to clarify their usage.
* In the diarization source factory (`audio/sources/factory.py`), VTTM files are now explicitly derived from RTTM for compatibility when both are provided, improving interoperability between formats.

**Documentation and Argument Handling**

* The argument documentation for `separate_speakers` in both `pyannote/separate.py` and `stereo/separate.py` is updated to clarify that `out_rttm_file` is now optional and considered legacy. [[1]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL78-R78) [[2]](diffhunk://#diff-d6155ae657f17c5b3b38778eb7074e34739d8caba7ee576882d30792c6f5cc4fL39-R39)
* The default value for `out_rttm_file` in `separate_speakers` is changed from `"out.rttm"` to `None`, reflecting its optional status.

**Conditional Output File Writing**

* Diarization results are only written to RTTM files if an output path is explicitly provided, preventing unnecessary file creation and aligning with the new optional/legacy status of RTTM output.