### PR TITLE
Reusable CLI arguments

### DIFF
--- a/verbatim_cli/args.py
+++ b/verbatim_cli/args.py
@@ -1,0 +1,133 @@
+"""CLI argument builder shared across verbatim tools."""
+
+import argparse
+
+from verbatim import __version__
+from verbatim.transcript.format.writer import LanguageStyle, ProbabilityStyle, SpeakerStyle, TimestampStyle
+
+
+class OptionalValueAction(argparse.Action):
+    """Action that allows an optional value; if omitted sets an empty string."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values if values is not None else "")
+
+
+def build_parser(prog: str = "verbatim") -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description="Verbatim: that's what she said")
+
+    parser.add_argument(
+        "input",
+        nargs="?",
+        default=None,
+        help="Path to the input audio file. Use '-' to read from stdin (expecting 16bit 16kHz mono PCM stream) or '>' to use microphone.",
+    )
+    parser.add_argument("-f", "--from", default="00:00.000", dest="start_time", help="Start time within the file in hh:mm:ss.ms or mm:ss.ms")
+    parser.add_argument("-t", "--to", default="", dest="stop_time", help="Stop time within the file in hh:mm:ss.ms or mm:ss.ms")
+    parser.add_argument("-o", "--outdir", default=".", help="Path to the output directory")
+    parser.add_argument("--diarization-strategy", choices=["pyannote", "stereo"], default="pyannote", help="Diarization strategy to use")
+    parser.add_argument(
+        "--vttm",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="Path to VTTM diarization file; if omitted, a minimal VTTM is created (and filled if diarization runs).",
+    )
+    parser.add_argument(
+        "-d",
+        "--diarization",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="(Deprecated) RTTM diarization file path; will be wrapped into a VTTM for processing.",
+    )
+    parser.add_argument(
+        "--separate", nargs="?", action=OptionalValueAction, default=None, help="Enables speaker voice separation and process each speaker separately"
+    )
+    parser.add_argument(
+        "-i",
+        "--isolate",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="Extract voices from background noise. Outputs files <name>-vocals.wav and <name>-noise.wav "
+        "if a name is provided, otherwise uses default names.",
+    )
+    parser.add_argument("-l", "--languages", nargs="*", help="Languages for speech recognition. Provide multiple values for multiple languages.")
+    parser.add_argument("-n", "--diarize", nargs="?", action=OptionalValueAction, default=None, help="Number of speakers in the audio file.")
+    parser.add_argument(
+        "-b",
+        "--nb_beams",
+        type=int,
+        default=None,
+        help="Number of parallel when resolving transcription. 1-3 for fast, 12-15 for high quality. Default is 9.",
+    )
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (specify multiple times for more verbosity)")
+    parser.add_argument("--version", action="version", version=f"{prog} {__version__}")
+    parser.add_argument("--cpu", action="store_true", help="Toggle CPU usage")
+    parser.add_argument("-s", "--stream", action="store_true", help="Set mode to low latency streaming")
+    parser.add_argument("--offline", action="store_true", help="Disallow any network/model downloads; use cache only")
+    parser.add_argument("--model-cache", default=None, help="Deterministic cache directory for models and downloads")
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Prefetch commonly used models into the cache and exit",
+    )
+    parser.add_argument(
+        "-w",
+        "--workdir",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="Set the working directory where temporary files may be written to (default is system temp directory)",
+    )
+    parser.add_argument("--ass", action="store_true", help="Enable ASS subtitle file output")
+    parser.add_argument("--docx", action="store_true", help="Enable Microsoft Word DOCX output")
+    parser.add_argument("--txt", action="store_true", help="Enable TXT file output")
+    parser.add_argument("--json", action="store_true", help="Enable json file output")
+    parser.add_argument("--md", action="store_true", help="Enable Markdown (MD) output")
+    parser.add_argument("--stdout", action="store_true", default=True, help="Enable stdout output (enabled by default)")
+    parser.add_argument("--stdout-nocolor", action="store_true", help="Enable stdout output without colors")
+    parser.add_argument(
+        "--format-timestamp",
+        type=lambda s: TimestampStyle[s],
+        choices=list(TimestampStyle),
+        default=TimestampStyle.minute,
+        help="Set the timestamp format: 'none' for no timestamps, 'start' for start time, 'range' for start and end times",
+    )
+    parser.add_argument(
+        "--format-speaker",
+        type=lambda s: SpeakerStyle[s],
+        choices=list(SpeakerStyle),
+        default=SpeakerStyle.change,
+        help=(
+            "Set the speaker format: 'none' for no speaker tags, "
+            "'change' to show the speaker only when it changes, "
+            "'always' to prefix every line with the speaker"
+        ),
+    )
+    parser.add_argument(
+        "--format-probability",
+        type=lambda s: ProbabilityStyle[s],
+        choices=list(ProbabilityStyle),
+        default=ProbabilityStyle.line,
+        help=(
+            "Set the probability format: choose between 'line' or 'word' "
+            "styles with optional thresholds (none, line, line_75, line_50, "
+            "line_25, word, word_75, word_50, word_25)"
+        ),
+    )
+    parser.add_argument(
+        "--format-language",
+        type=lambda s: LanguageStyle[s],
+        choices=list(LanguageStyle),
+        default=LanguageStyle.change,
+        help=(
+            "Set the language format: 'none' for no language tags, "
+            "'change' to display language when it changes, "
+            "'always' to show language on each line"
+        ),
+    )
+    parser.add_argument("-e", "--eval", nargs="?", default=None, help="Path to reference json file")
+
+    return parser

--- a/verbatim_cli/configure.py
+++ b/verbatim_cli/configure.py
@@ -1,0 +1,82 @@
+"""Helpers to build configs and execution inputs from CLI args."""
+
+import logging
+import os
+from typing import List, Optional
+
+from verbatim.audio.sources.sourceconfig import SourceConfig
+from verbatim.config import Config
+from verbatim.transcript.format.writer import TranscriptWriterConfig
+
+
+def compute_log_level(verbose: int) -> int:
+    log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
+    return log_levels[min(verbose, len(log_levels) - 1)]
+
+
+def make_config(args) -> Config:
+    config: Config = Config(
+        device="cpu" if args.cpu else "auto",
+        output_dir=args.outdir,
+        working_dir=args.workdir if args.workdir is not None else "",
+        stream=args.stream,
+        offline=args.offline,
+        model_cache_dir=args.model_cache,
+    )
+    config.lang = args.languages if args.languages else ["en"]
+    return config
+
+
+def make_write_config(args, log_level: int) -> TranscriptWriterConfig:
+    write_config: TranscriptWriterConfig = TranscriptWriterConfig()
+    write_config.timestamp_style = args.format_timestamp
+    write_config.probability_style = args.format_probability
+    write_config.speaker_style = args.format_speaker
+    write_config.language_style = args.format_language
+    write_config.verbose = log_level <= logging.INFO
+    return write_config
+
+
+def resolve_diarize(args) -> Optional[int]:
+    if args.diarize == "":
+        return 0
+    if args.diarize is None:
+        return None
+    return int(args.diarize)
+
+
+def make_source_config(args, diarize: Optional[int]) -> SourceConfig:
+    vttm_path = args.vttm if args.vttm not in (None, "") else None
+    return SourceConfig(
+        isolate=args.isolate,
+        diarize=diarize,
+        diarization_file=args.diarization,
+        diarization_strategy=args.diarization_strategy,
+        vttm_file=vttm_path,
+    )
+
+
+def build_output_formats(args) -> List[str]:
+    output_formats: List[str] = []
+    if args.ass:
+        output_formats.append("ass")
+    if args.docx:
+        output_formats.append("docx")
+    if args.txt:
+        output_formats.append("txt")
+    if args.md:
+        output_formats.append("md")
+    if args.json:
+        output_formats.append("json")
+    if args.stdout:
+        output_formats.append("stdout")
+    if args.stdout_nocolor:
+        output_formats.append("stdout-nocolor")
+    return output_formats
+
+
+def build_prefixes(config: Config, source_path: str):
+    input_name_no_ext = os.path.splitext(os.path.split(source_path)[-1])[0]
+    output_prefix_no_ext = os.path.join(config.output_dir, input_name_no_ext)
+    working_prefix_no_ext = os.path.join(config.working_dir, input_name_no_ext)
+    return output_prefix_no_ext, working_prefix_no_ext

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -1,148 +1,30 @@
-import argparse
 import logging
 import os
 import sys
 from typing import List
-
-from verbatim import __version__
-from verbatim.transcript.format.writer import (
-    LanguageStyle,
-    ProbabilityStyle,
-    SpeakerStyle,
-    TimestampStyle,
-)
 
 LOG = logging.getLogger(__name__)
 
 
 def main():
     # pylint: disable=import-outside-toplevel
-    class OptionalValueAction(argparse.Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            # Set the attribute to the provided value or an empty string if no value is given
-            setattr(namespace, self.dest, values if values is not None else "")
+    from verbatim_cli.args import build_parser
+    from verbatim_cli.configure import (
+        build_output_formats,
+        build_prefixes,
+        compute_log_level,
+        make_config,
+        make_source_config,
+        make_write_config,
+        resolve_diarize,
+    )
+    from verbatim_cli.env import load_env_file
+    from verbatim_cli.run_single import build_audio_sources, run_execute
 
-    parser = argparse.ArgumentParser(prog="verbatim", description="Verbatim: that's what she said")
-
-    # Specify the command line arguments
-    parser.add_argument(
-        "input",
-        nargs="?",
-        default=None,
-        help="Path to the input audio file. Use '-' to read from stdin (expecting 16bit 16kHz mono PCM stream) or '>' to use microphone.",
-    )
-    parser.add_argument("-f", "--from", default="00:00.000", dest="start_time", help="Start time within the file in hh:mm:ss.ms or mm:ss.ms")
-    parser.add_argument("-t", "--to", default="", dest="stop_time", help="Stop time within the file in hh:mm:ss.ms or mm:ss.ms")
-    parser.add_argument("-o", "--outdir", default=".", help="Path to the output directory")
-    parser.add_argument("--diarization-strategy", choices=["pyannote", "stereo"], default="pyannote", help="Diarization strategy to use")
-    parser.add_argument(
-        "--vttm",
-        nargs="?",
-        action=OptionalValueAction,
-        default=None,
-        help="Path to VTTM diarization file; if omitted, a minimal VTTM is created (and filled if diarization runs).",
-    )
-    parser.add_argument(
-        "-d",
-        "--diarization",
-        nargs="?",
-        action=OptionalValueAction,
-        default=None,
-        help="(Deprecated) RTTM diarization file path; will be wrapped into a VTTM for processing.",
-    )
-    parser.add_argument(
-        "--separate", nargs="?", action=OptionalValueAction, default=None, help="Enables speaker voice separation and process each speaker separately"
-    )
-    parser.add_argument(
-        "-i",
-        "--isolate",
-        nargs="?",
-        action=OptionalValueAction,
-        default=None,
-        help="Extract voices from background noise. Outputs files <name>-vocals.wav and <name>-noise.wav "
-        "if a name is provided, otherwise uses default names.",
-    )
-    parser.add_argument("-l", "--languages", nargs="*", help="Languages for speech recognition. Provide multiple values for multiple languages.")
-    parser.add_argument("-n", "--diarize", nargs="?", action=OptionalValueAction, default=None, help="Number of speakers in the audio file.")
-    parser.add_argument(
-        "-b",
-        "--nb_beams",
-        type=int,
-        default=None,
-        help="Number of parallel when resolving transcription. 1-3 for fast, 12-15 for high quality. Default is 9.",
-    )
-    parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (specify multiple times for more verbosity)")
-    parser.add_argument("--version", action="version", version=f"verbatim {__version__}")
-    parser.add_argument("--cpu", action="store_true", help="Toggle CPU usage")
-    parser.add_argument("-s", "--stream", action="store_true", help="Set mode to low latency streaming")
-    parser.add_argument("--offline", action="store_true", help="Disallow any network/model downloads; use cache only")
-    parser.add_argument("--model-cache", default=None, help="Deterministic cache directory for models and downloads")
-    parser.add_argument(
-        "--install",
-        action="store_true",
-        help="Prefetch commonly used models into the cache and exit",
-    )
-    parser.add_argument(
-        "-w",
-        "--workdir",
-        nargs="?",
-        action=OptionalValueAction,
-        default=None,
-        help="Set the working directory where temporary files may be written to (default is system temp directory)",
-    )
-    parser.add_argument("--ass", action="store_true", help="Enable ASS subtitle file output")
-    parser.add_argument("--docx", action="store_true", help="Enable Microsoft Word DOCX output")
-    parser.add_argument("--txt", action="store_true", help="Enable TXT file output")
-    parser.add_argument("--json", action="store_true", help="Enable json file output")
-    parser.add_argument("--md", action="store_true", help="Enable Markdown (MD) output")
-    parser.add_argument("--stdout", action="store_true", default=True, help="Enable stdout output (enabled by default)")
-    parser.add_argument("--stdout-nocolor", action="store_true", help="Enable stdout output without colors")
-    parser.add_argument(
-        "--format-timestamp",
-        type=lambda s: TimestampStyle[s],
-        choices=list(TimestampStyle),
-        default=TimestampStyle.minute,
-        help="Set the timestamp format: 'none' for no timestamps, 'start' for start time, 'range' for start and end times",
-    )
-    parser.add_argument(
-        "--format-speaker",
-        type=lambda s: SpeakerStyle[s],
-        choices=list(SpeakerStyle),
-        default=SpeakerStyle.change,
-        help=(
-            "Set the speaker format: 'none' for no speaker tags, "
-            "'change' to show the speaker only when it changes, "
-            "'always' to prefix every line with the speaker"
-        ),
-    )
-    parser.add_argument(
-        "--format-probability",
-        type=lambda s: ProbabilityStyle[s],
-        choices=list(ProbabilityStyle),
-        default=ProbabilityStyle.line,
-        help=(
-            "Set the probability format: choose between 'line' or 'word' "
-            "styles with optional thresholds (none, line, line_75, line_50, "
-            "line_25, word, word_75, word_50, word_25)"
-        ),
-    )
-    parser.add_argument(
-        "--format-language",
-        type=lambda s: LanguageStyle[s],
-        choices=list(LanguageStyle),
-        default=LanguageStyle.change,
-        help=(
-            "Set the language format: 'none' for no language tags, "
-            "'change' to display language when it changes, "
-            "'always' to show language on each line"
-        ),
-    )
-    parser.add_argument("-e", "--eval", nargs="?", default=None, help="Path to reference json file")
+    parser = build_parser(prog="verbatim")
 
     args = parser.parse_args()
-    # Set logging level based on verbosity
-    log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
-    log_level = log_levels[min(args.verbose, len(log_levels) - 1)]
+    log_level = compute_log_level(args.verbose)
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
@@ -154,26 +36,13 @@ def main():
     )
 
     # load the values from the .env file, if present
-    from verbatim_cli.env import load_env_file
-
     load_env_file()
 
     # Check if the version option is specified
     if hasattr(args, "version") and args.version:
         return  # Exit if the version option is specified
 
-    from verbatim.config import Config
-
-    config: Config = Config(
-        device="cpu" if args.cpu else "auto",
-        output_dir=args.outdir,
-        working_dir=args.workdir if args.workdir is not None else "",
-        stream=args.stream,
-        offline=args.offline,
-        model_cache_dir=args.model_cache,
-    )
-
-    config.lang = args.languages if args.languages else ["en"]
+    config = make_config(args)
 
     # Handle install-only mode
     if args.install:
@@ -185,42 +54,13 @@ def main():
         return
 
     source_path = args.input
-    input_name_no_ext = os.path.splitext(os.path.split(source_path)[-1])[0]
-    output_prefix_no_ext = os.path.join(config.output_dir, input_name_no_ext)
-    working_prefix_no_ext = os.path.join(config.working_dir, input_name_no_ext)
+    output_prefix_no_ext, working_prefix_no_ext = build_prefixes(config, source_path)
 
-    # Set output formats
-    from verbatim.transcript.format.writer import TranscriptWriterConfig
+    write_config = make_write_config(args, log_level)
 
-    write_config: TranscriptWriterConfig = TranscriptWriterConfig()
-    write_config.timestamp_style = args.format_timestamp
-    write_config.probability_style = args.format_probability
-    write_config.speaker_style = args.format_speaker
-    write_config.language_style = args.format_language
-    write_config.verbose = log_level <= logging.INFO
+    output_formats = build_output_formats(args)
 
-    output_formats = []
-    if args.ass:
-        output_formats.append("ass")
-    if args.docx:
-        output_formats.append("docx")
-    if args.txt:
-        output_formats.append("txt")
-    if args.md:
-        output_formats.append("md")
-    if args.json:
-        output_formats.append("json")
-    if args.stdout:
-        output_formats.append("stdout")
-    if args.stdout_nocolor:
-        output_formats.append("stdout-nocolor")
-
-    if args.diarize == "":
-        diarize = 0
-    elif args.diarize is None:
-        diarize = None
-    else:
-        diarize = int(args.diarize)
+    diarize = resolve_diarize(args)
 
     LOG.info(
         "Diarization settings: strategy=%s diarize=%s vttm=%s rttm=%s separate=%s",
@@ -231,55 +71,18 @@ def main():
         args.separate,
     )
 
-    from verbatim.audio.sources.sourceconfig import SourceConfig
+    source_config = make_source_config(args, diarize)
 
-    vttm_path = args.vttm if args.vttm not in (None, "") else None
-    source_config: SourceConfig = SourceConfig(
-        isolate=args.isolate,
-        diarize=diarize,
-        diarization_file=args.diarization,
-        diarization_strategy=args.diarization_strategy,
-        vttm_file=vttm_path,
+    audio_sources: List = build_audio_sources(
+        args=args,
+        config=config,
+        source_config=source_config,
+        source_path=source_path,
+        working_prefix_no_ext=working_prefix_no_ext,
+        output_prefix_no_ext=output_prefix_no_ext,
     )
 
-    from verbatim.audio.sources.audiosource import AudioSource
-
-    audio_sources: List[AudioSource] = []
-
-    if args.separate:
-        # perform the transcription by combining the transcript of
-        # multiple audio sources separated from a single one
-        from verbatim.audio.sources.factory import create_separate_speaker_sources
-
-        audio_sources += create_separate_speaker_sources(
-            strategy=args.separate or "pyannote",
-            source_config=source_config,
-            device=config.device,
-            input_source=source_path,
-            start_time=args.start_time,
-            stop_time=args.stop_time,
-            working_prefix_no_ext=working_prefix_no_ext,
-            output_prefix_no_ext=output_prefix_no_ext,
-        )
-    else:
-        from verbatim.audio.sources.factory import create_audio_source
-
-        audio_sources.append(
-            create_audio_source(
-                source_config=source_config,
-                device=config.device,
-                input_source=source_path,
-                start_time=args.start_time,
-                stop_time=args.stop_time,
-                working_prefix_no_ext=working_prefix_no_ext,
-                output_prefix_no_ext=output_prefix_no_ext,
-                stream=config.stream,
-            )
-        )
-
-    from verbatim.verbatim import execute
-
-    execute(
+    run_execute(
         source_path=source_path,
         config=config,
         write_config=write_config,

--- a/verbatim_cli/run_single.py
+++ b/verbatim_cli/run_single.py
@@ -1,0 +1,70 @@
+"""Single-file execution helpers for the CLI."""
+
+from typing import List
+
+from verbatim.audio.sources.audiosource import AudioSource
+from verbatim.verbatim import execute
+
+
+def build_audio_sources(
+    *,
+    args,
+    config,
+    source_config,
+    source_path: str,
+    working_prefix_no_ext: str,
+    output_prefix_no_ext: str,
+) -> List[AudioSource]:
+    audio_sources: List[AudioSource] = []
+    if args.separate:
+        from verbatim.audio.sources.factory import create_separate_speaker_sources
+
+        audio_sources += create_separate_speaker_sources(
+            strategy=args.separate or "pyannote",
+            source_config=source_config,
+            device=config.device,
+            input_source=source_path,
+            start_time=args.start_time,
+            stop_time=args.stop_time,
+            working_prefix_no_ext=working_prefix_no_ext,
+            output_prefix_no_ext=output_prefix_no_ext,
+        )
+    else:
+        from verbatim.audio.sources.factory import create_audio_source
+
+        audio_sources.append(
+            create_audio_source(
+                source_config=source_config,
+                device=config.device,
+                input_source=source_path,
+                start_time=args.start_time,
+                stop_time=args.stop_time,
+                working_prefix_no_ext=working_prefix_no_ext,
+                output_prefix_no_ext=output_prefix_no_ext,
+                stream=config.stream,
+            )
+        )
+    return audio_sources
+
+
+def run_execute(
+    *,
+    source_path: str,
+    config,
+    write_config,
+    audio_sources: List[AudioSource],
+    output_formats,
+    output_prefix_no_ext: str,
+    working_prefix_no_ext: str,
+    eval_file,
+):
+    execute(
+        source_path=source_path,
+        config=config,
+        write_config=write_config,
+        audio_sources=audio_sources,
+        output_formats=output_formats,
+        output_prefix_no_ext=output_prefix_no_ext,
+        working_prefix_no_ext=working_prefix_no_ext,
+        eval_file=eval_file,
+    )


### PR DESCRIPTION
This pull request refactors the CLI implementation for the `verbatim` tool by modularizing argument parsing, configuration building, and execution logic into dedicated helper modules. The main entry point (`main.py`) is simplified by delegating responsibilities to new files, improving maintainability and readability. No functional changes to CLI options are introduced; instead, the code is reorganized for clarity and separation of concerns.

### CLI argument parsing and configuration (most important):

* Moved CLI argument parsing logic from `main.py` to a new `verbatim_cli/args.py` module, encapsulating argument definitions and custom actions in the `build_parser` function.
* Extracted configuration building and output format selection to `verbatim_cli/configure.py`, providing helper functions such as `make_config`, `make_write_config`, `build_output_formats`, and `build_prefixes`.

### Execution logic refactoring:

* Moved audio source creation and execution logic to `verbatim_cli/run_single.py`, defining `build_audio_sources` and `run_execute` for single-file processing.

### Main entry point simplification:

* Updated `main.py` to use the new helper modules for argument parsing, configuration, and execution, removing inline logic and reducing complexity. [[1]](diffhunk://#diff-4a25e80b5dc75aa65bd385e39549120342d4f139805951475a3e48a5ea1e6dc6L1-R27) [[2]](diffhunk://#diff-4a25e80b5dc75aa65bd385e39549120342d4f139805951475a3e48a5ea1e6dc6L157-R45) [[3]](diffhunk://#diff-4a25e80b5dc75aa65bd385e39549120342d4f139805951475a3e48a5ea1e6dc6L188-R63) [[4]](diffhunk://#diff-4a25e80b5dc75aa65bd385e39549120342d4f139805951475a3e48a5ea1e6dc6L234-R85)

These changes collectively improve the codebase structure and make it easier to maintain and extend the CLI functionality.