### PR TITLE
Support config file

### DIFF
--- a/verbatim/audio/sources/sourceconfig.py
+++ b/verbatim/audio/sources/sourceconfig.py
@@ -7,8 +7,8 @@ Annotation = object  # pylint: disable=invalid-name
 @dataclass
 class SourceConfig:
     isolate: Optional[bool] = None
-    diarize: Optional[int] = None
+    diarize_strategy: Optional[str] = None
+    speakers: Optional[int] = None
     diarization: Optional[Annotation] = None  # verbatim_rttm.Annotation expected at runtime
     diarization_file: Optional[str] = None  # legacy RTTM; when set, we derive from vttm
-    diarization_strategy: str = "pyannote"
     vttm_file: Optional[str] = None

--- a/verbatim_cli/args.py
+++ b/verbatim_cli/args.py
@@ -24,7 +24,7 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
     parser.add_argument("-f", "--from", default="00:00.000", dest="start_time", help="Start time within the file in hh:mm:ss.ms or mm:ss.ms")
     parser.add_argument("-t", "--to", default="", dest="stop_time", help="Stop time within the file in hh:mm:ss.ms or mm:ss.ms")
     parser.add_argument("-o", "--outdir", default=".", help="Path to the output directory")
-    parser.add_argument("--diarization-strategy", choices=["pyannote", "stereo"], default="pyannote", help="Diarization strategy to use")
+    parser.add_argument("--diarize", choices=["pyannote", "stereo", "channels"], default=None, help="Diarization strategy to use")
     parser.add_argument(
         "--vttm",
         nargs="?",
@@ -32,14 +32,7 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         default=None,
         help="Path to VTTM diarization file; if omitted, a minimal VTTM is created (and filled if diarization runs).",
     )
-    parser.add_argument(
-        "-d",
-        "--diarization",
-        nargs="?",
-        action=OptionalValueAction,
-        default=None,
-        help="(Deprecated) RTTM diarization file path; will be wrapped into a VTTM for processing.",
-    )
+    parser.add_argument("-d", "--diarization", nargs="?", action=OptionalValueAction, default=None, help="RTTM diarization file path")
     parser.add_argument(
         "--separate", nargs="?", action=OptionalValueAction, default=None, help="Enables speaker voice separation and process each speaker separately"
     )
@@ -53,7 +46,14 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         "if a name is provided, otherwise uses default names.",
     )
     parser.add_argument("-l", "--languages", nargs="*", help="Languages for speech recognition. Provide multiple values for multiple languages.")
-    parser.add_argument("-n", "--diarize", nargs="?", action=OptionalValueAction, default=None, help="Number of speakers in the audio file.")
+    parser.add_argument(
+        "-n",
+        "--speakers",
+        nargs="?",
+        action=OptionalValueAction,
+        default=None,
+        help="Number of speakers (int), 'auto' for automatic, or '0' to disable fixed-count hints.",
+    )
     parser.add_argument(
         "-b",
         "--nb_beams",
@@ -67,6 +67,7 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
     parser.add_argument("-s", "--stream", action="store_true", help="Set mode to low latency streaming")
     parser.add_argument("--offline", action="store_true", help="Disallow any network/model downloads; use cache only")
     parser.add_argument("--model-cache", default=None, help="Deterministic cache directory for models and downloads")
+    parser.add_argument("--config", help="Path to YAML or JSON config file for defaults")
     parser.add_argument(
         "--install",
         action="store_true",

--- a/verbatim_cli/config_file.py
+++ b/verbatim_cli/config_file.py
@@ -1,0 +1,116 @@
+"""Config file loading and parser defaults application for CLIs."""
+
+import argparse
+import fnmatch
+import json
+from argparse import Namespace
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from verbatim.transcript.format.writer import LanguageStyle, ProbabilityStyle, SpeakerStyle, TimestampStyle
+
+OUTPUT_FLAGS = ("ass", "docx", "txt", "json", "md", "stdout", "stdout_nocolor")
+
+
+def load_config_file(path: str) -> Dict[str, Any]:
+    config_path = Path(path).expanduser()
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    suffix = config_path.suffix.lower()
+    if suffix in (".yml", ".yaml"):
+        with config_path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    if suffix == ".json":
+        with config_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    raise ValueError(f"Unsupported config file format: {suffix}")
+
+
+def _normalize_styles(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = dict(cfg)
+    if "format_timestamp" in normalized and isinstance(normalized["format_timestamp"], str):
+        normalized["format_timestamp"] = TimestampStyle[normalized["format_timestamp"]]
+    if "format_speaker" in normalized and isinstance(normalized["format_speaker"], str):
+        normalized["format_speaker"] = SpeakerStyle[normalized["format_speaker"]]
+    if "format_probability" in normalized and isinstance(normalized["format_probability"], str):
+        normalized["format_probability"] = ProbabilityStyle[normalized["format_probability"]]
+    if "format_language" in normalized and isinstance(normalized["format_language"], str):
+        normalized["format_language"] = LanguageStyle[normalized["format_language"]]
+    return normalized
+
+
+def _flatten_output(output_section: Dict[str, Any]) -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    if "formats" in output_section and isinstance(output_section["formats"], list):
+        selected = set(output_section["formats"])
+        for flag in OUTPUT_FLAGS:
+            flat[flag] = flag.replace("_", "-") in selected or flag in selected
+    else:
+        for flag in OUTPUT_FLAGS:
+            if flag in output_section:
+                flat[flag] = output_section[flag]
+    return flat
+
+
+def _flatten_format(format_section: Dict[str, Any]) -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    for key in ("timestamp", "speaker", "probability", "language"):
+        fmt_key = f"format_{key}"
+        if key in format_section:
+            flat[fmt_key] = format_section[key]
+    return flat
+
+
+def flatten_profile(profile: Dict[str, Any]) -> Dict[str, Any]:
+    flat: Dict[str, Any] = {}
+    for key, val in profile.items():
+        if key == "match":
+            continue
+        if key == "output" and isinstance(val, dict):
+            flat.update(_flatten_output(val))
+            continue
+        if key == "format" and isinstance(val, dict):
+            flat.update(_flatten_format(val))
+            continue
+        flat[key] = val
+    return _normalize_styles(flat)
+
+
+def _match_profile(profile: Dict[str, Any], filename: Optional[str]) -> bool:
+    match = profile.get("match")
+    if match is None:
+        return True  # wildcard
+    patterns = match.get("filename") if isinstance(match, dict) else None
+    if not patterns:
+        return True
+    if filename is None:
+        return False
+    return any(fnmatch.fnmatch(Path(filename).name, pattern) for pattern in patterns)
+
+
+def select_profile(config_data: Dict[str, Any], filename: Optional[str]) -> Dict[str, Any]:
+    if not config_data:
+        return {}
+    profiles = config_data.get("profiles")
+    if isinstance(profiles, list) and profiles:
+        fallback: Optional[Dict[str, Any]] = None
+        for profile in profiles:
+            if not isinstance(profile, dict):
+                continue
+            if _match_profile(profile, filename):
+                return flatten_profile(profile)
+            if profile.get("match") is None and fallback is None:
+                fallback = profile
+        return flatten_profile(fallback) if fallback else {}
+    # Treat entire config as single profile
+    return flatten_profile(config_data)
+
+
+def merge_args(base_defaults: Namespace, profile_overrides: Dict[str, Any], user_args: Namespace) -> Namespace:
+    merged = vars(base_defaults).copy()
+    merged.update(profile_overrides)
+    merged.update(vars(user_args))
+    return argparse.Namespace(**merged)

--- a/verbatim_cli/configure.py
+++ b/verbatim_cli/configure.py
@@ -37,21 +37,24 @@ def make_write_config(args, log_level: int) -> TranscriptWriterConfig:
     return write_config
 
 
-def resolve_diarize(args) -> Optional[int]:
-    if args.diarize == "":
-        return 0
-    if args.diarize is None:
+def resolve_speakers(args) -> Optional[int]:
+    if args.speakers in (None, "auto"):
         return None
-    return int(args.diarize)
+    if args.speakers in ("", 0, "0"):
+        return 0
+    try:
+        return int(args.speakers)
+    except (TypeError, ValueError):
+        return None
 
 
-def make_source_config(args, diarize: Optional[int]) -> SourceConfig:
+def make_source_config(args, speakers: Optional[int]) -> SourceConfig:
     vttm_path = args.vttm if args.vttm not in (None, "") else None
     return SourceConfig(
         isolate=args.isolate,
-        diarize=diarize,
+        diarize_strategy=args.diarize,
+        speakers=speakers,
         diarization_file=args.diarization,
-        diarization_strategy=args.diarization_strategy,
         vttm_file=vttm_path,
     )
 


### PR DESCRIPTION
This pull request introduces a refactor to how diarization strategy and speaker count are handled in audio source processing, and adds support for loading configuration defaults from YAML/JSON files for batch processing. The changes improve clarity and flexibility for configuring diarization and speaker separation, especially in batch workflows.

### Diarization and Speaker Configuration Refactor

* Replaces the ambiguous `diarize` and `diarization_strategy` fields in `SourceConfig` with `diarize_strategy` (for strategy selection) and `speakers` (for speaker count), updating all usages throughout `verbatim/audio/sources/factory.py` and related CLI argument parsing. This clarifies intent and separates strategy from count. [[1]](diffhunk://#diff-298434e026812bd9bed044edbbb7082dbef243ea1634beb6bec36c59668b253aL10-L13) [[2]](diffhunk://#diff-7c05d3c8bd0c64214ca3e76aa63ca61be6e3a55790b91880a9ffbee8aa459901L27-R35) [[3]](diffhunk://#diff-7c05d3c8bd0c64214ca3e76aa63ca61be6e3a55790b91880a9ffbee8aa459901L56-R56) [[4]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L93-R93) [[5]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L104-R112) [[6]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L139-R136) [[7]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L150-R156) [[8]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R172-R179) [[9]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L196-R195) [[10]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L226-R227) [[11]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L276-R279) [[12]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L294-R288)
* Updates logic to consistently use `speakers` for the number of speakers and `diarize_strategy` for diarization method, including proper handling of default values and disabling hints when speaker count is 0 or blank. [[1]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L150-R156) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0R172-R179) [[3]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L226-R227) [[4]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L276-R279)

### Batch CLI Config File Support

* Adds a new module `verbatim_cli/config_file.py` to support loading configuration defaults from YAML or JSON files, including profile selection and merging logic for batch processing.
* Modifies `verbatim_batch/main.py` to support loading and merging config file profiles with command-line arguments, enabling per-file and global configuration overrides. [[1]](diffhunk://#diff-60bf43b3bf7465f8ddc59fbd94b4ce092f4627143884f0681139c8275e6d5321R4-R17) [[2]](diffhunk://#diff-60bf43b3bf7465f8ddc59fbd94b4ce092f4627143884f0681139c8275e6d5321L63-R73) [[3]](diffhunk://#diff-60bf43b3bf7465f8ddc59fbd94b4ce092f4627143884f0681139c8275e6d5321R98-L97) [[4]](diffhunk://#diff-60bf43b3bf7465f8ddc59fbd94b4ce092f4627143884f0681139c8275e6d5321R113-R132) [[5]](diffhunk://#diff-60bf43b3bf7465f8ddc59fbd94b4ce092f4627143884f0681139c8275e6d5321L131-R147)
* Adds a `--config` argument to the CLI for specifying the config file path.

### CLI Argument Improvements

* Refactors argument names for diarization: `--diarize` now selects strategy, and `--speakers` (previously `--diarize` with int) specifies the number of speakers, with improved help text for clarity. [[1]](diffhunk://#diff-7c05d3c8bd0c64214ca3e76aa63ca61be6e3a55790b91880a9ffbee8aa459901L27-R35) [[2]](diffhunk://#diff-7c05d3c8bd0c64214ca3e76aa63ca61be6e3a55790b91880a9ffbee8aa459901L56-R56)

These changes make the diarization and speaker handling more explicit and robust, and allow batch workflows to be configured more flexibly via external config files.