### PR TITLE
stereo diarizer is now energy / channel diarizer

### DIFF
--- a/tests/diarize/test_stereo_diarization.py
+++ b/tests/diarize/test_stereo_diarization.py
@@ -11,12 +11,12 @@ soundfile_available = importlib.util.find_spec("soundfile") is not None
 # pylint: disable=import-outside-toplevel
 
 
-class TestStereoDiarization(unittest.TestCase):
+class TestEnergyDiarization(unittest.TestCase):
     @unittest.skipUnless(pyannote_available, "pyannote not available")
     def test_determine_speaker_silence(self):
-        from verbatim_diarization.stereo.diarize import StereoDiarization
+        from verbatim_diarization.stereo.diarize import EnergyDiarization
 
-        diarizer = StereoDiarization()
+        diarizer = EnergyDiarization()
         # pylint: disable=protected-access
         speaker = diarizer._determine_speaker(0.0, 0.0, 0.0, 0.0)
         self.assertEqual(speaker, "UNKNOWN")
@@ -25,7 +25,7 @@ class TestStereoDiarization(unittest.TestCase):
     def test_compute_diarization_silence(self):
         import soundfile as sf  # type: ignore
 
-        from verbatim_diarization.stereo.diarize import StereoDiarization
+        from verbatim_diarization.stereo.diarize import EnergyDiarization
 
         sample_rate = 16000
         audio = np.zeros((sample_rate, 2), dtype=np.float32)
@@ -34,7 +34,7 @@ class TestStereoDiarization(unittest.TestCase):
             tmp_path = tmp.name
 
         try:
-            diarizer = StereoDiarization()
+            diarizer = EnergyDiarization()
             annotation = diarizer.compute_diarization(tmp_path, segment_duration=0.5)
             self.assertEqual(len(annotation), 0)
         finally:

--- a/verbatim/audio/sources/factory.py
+++ b/verbatim/audio/sources/factory.py
@@ -37,7 +37,7 @@ def compute_diarization(
         file_path: Path to audio file
         device: Device to use ('cpu' or 'cuda')
         rttm_file: Optional path to save RTTM file
-        strategy: Diarization strategy ('pyannote' or 'stereo')
+        strategy: Diarization strategy ('pyannote', 'energy', or 'channel')
     nb_speakers: Optional number of speakers
 
         PyAnnote Annotation object
@@ -106,10 +106,10 @@ def create_audio_source(
                 file_path=input_source,
                 start_time=samples_to_seconds(start_sample),
                 end_time=samples_to_seconds(stop_sample) if stop_sample else None,
-                preserve_channels=source_config.diarize_strategy == "stereo",
+                preserve_channels=source_config.diarize_strategy in ("energy", "channel"),
             )
 
-        preserve_channels = source_config.diarize_strategy == "stereo"
+        preserve_channels = source_config.diarize_strategy in ("energy", "channel")
 
         input_source = convert_to_wav(
             input_path=input_source,
@@ -133,7 +133,8 @@ def create_audio_source(
         if source_config.vttm_file and not os.path.exists(source_config.vttm_file):
             LOG.info("No VTTM provided; creating minimal VTTM placeholder at %s", source_config.vttm_file)
             audio_id = os.path.splitext(os.path.basename(input_source))[0]
-            audio_ref = AudioRef(id=audio_id, path=input_source, channel="stereo" if source_config.diarize_strategy == "stereo" else "1")
+            preserve_channels = source_config.diarize_strategy in ("energy", "channel")
+            audio_ref = AudioRef(id=audio_id, path=input_source, channel="stereo" if preserve_channels else "1")
             write_vttm(source_config.vttm_file, audio=[audio_ref], annotation=RTTMAnnotation())
         if source_config.vttm_file:
             try:
@@ -192,7 +193,7 @@ def create_audio_source(
         start_sample=start_sample,
         end_sample=stop_sample,
         diarization=source_config.diarization,
-        preserve_channels=source_config.diarize_strategy == "stereo",
+        preserve_channels=source_config.diarize_strategy in ("energy", "channel"),
     )
 
 

--- a/verbatim_cli/args.py
+++ b/verbatim_cli/args.py
@@ -24,7 +24,7 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
     parser.add_argument("-f", "--from", default="00:00.000", dest="start_time", help="Start time within the file in hh:mm:ss.ms or mm:ss.ms")
     parser.add_argument("-t", "--to", default="", dest="stop_time", help="Stop time within the file in hh:mm:ss.ms or mm:ss.ms")
     parser.add_argument("-o", "--outdir", default=".", help="Path to the output directory")
-    parser.add_argument("--diarize", choices=["pyannote", "stereo", "channels"], default=None, help="Diarization strategy to use")
+    parser.add_argument("--diarize", choices=["pyannote", "energy", "channel"], default=None, help="Diarization strategy to use")
     parser.add_argument(
         "--vttm",
         nargs="?",

--- a/verbatim_diarization/channel/__init__.py
+++ b/verbatim_diarization/channel/__init__.py
@@ -1,0 +1,3 @@
+from .diarize import ChannelDiarization
+
+__all__ = ["ChannelDiarization"]

--- a/verbatim_diarization/channel/diarize.py
+++ b/verbatim_diarization/channel/diarize.py
@@ -1,0 +1,52 @@
+import logging
+import os
+from typing import Optional
+
+import soundfile as sf
+
+from verbatim_diarization.diarize.base import DiarizationStrategy
+from verbatim_rttm import Annotation, AudioRef, Segment, write_vttm
+
+LOG = logging.getLogger(__name__)
+
+
+class ChannelDiarization(DiarizationStrategy):
+    """Treat each channel as a separate speaker without further diarization."""
+
+    def __init__(self, speaker_labels: Optional[dict[int, str]] = None):
+        self.speaker_labels = speaker_labels or {}
+
+    def compute_diarization(self, file_path: str, out_rttm_file: Optional[str] = None, out_vttm_file: Optional[str] = None, **kwargs) -> Annotation:
+        audio, sample_rate = sf.read(file_path)
+        audio_info = sf.info(file_path)
+        LOG.info("Input file channels: %s, sample rate: %s", audio_info.channels, audio_info.samplerate)
+
+        if audio.ndim < 2 or audio.shape[1] < 1:
+            raise ValueError("Channel diarization requires multi-channel audio")
+
+        uri = os.path.splitext(os.path.basename(file_path))[0]
+        duration = len(audio) / sample_rate
+
+        segments = []
+        audio_refs = []
+        num_channels = audio.shape[1]
+        for idx in range(num_channels):
+            speaker = self.speaker_labels.get(idx, f"SPEAKER_{idx}")
+            segments.append(Segment(start=0.0, end=duration, speaker=speaker, file_id=uri))
+            audio_refs.append(AudioRef(id=f"{uri}_ch{idx}", path=file_path, channel=str(idx)))
+
+        annotation = Annotation(segments=segments, file_id=uri)
+
+        if out_rttm_file:
+            os.makedirs(os.path.dirname(out_rttm_file) or ".", exist_ok=True)
+            with open(out_rttm_file, "w", encoding="utf-8") as f:
+                for segment, _track, label in annotation.itertracks(yield_label=True):  # pyright: ignore[reportAssignmentType]
+                    f.write(f"SPEAKER {uri} 1 {segment.start:.3f} {segment.duration:.3f} <NA> <NA> {label} <NA> <NA>\n")
+            LOG.info("Wrote channel diarization to RTTM file: %s", out_rttm_file)
+
+        if out_vttm_file:
+            os.makedirs(os.path.dirname(out_vttm_file) or ".", exist_ok=True)
+            write_vttm(out_vttm_file, audio=audio_refs, annotation=annotation)
+            LOG.info("Wrote channel diarization to VTTM file: %s", out_vttm_file)
+
+        return annotation

--- a/verbatim_diarization/diarize/factory.py
+++ b/verbatim_diarization/diarize/factory.py
@@ -18,7 +18,7 @@ def create_diarizer(strategy: str = "pyannote", device: str = "cpu", huggingface
     Factory function to create diarization strategy instances.
 
     Args:
-        strategy: Name of the strategy to use ('pyannote' or 'stereo')
+        strategy: Name of the strategy to use ('pyannote', 'energy', 'channel')
         device: Device to use for PyAnnote ('cpu' or 'cuda')
         huggingface_token: Token for PyAnnote Hub
         **kwargs: Additional strategy-specific parameters
@@ -49,9 +49,15 @@ def create_diarizer(strategy: str = "pyannote", device: str = "cpu", huggingface
         from verbatim_diarization.pyannote import PyAnnoteDiarization
 
         return PyAnnoteDiarization(device=device, huggingface_token=token)
-    elif strategy == "stereo":
-        from verbatim_diarization.stereo import StereoDiarization
 
-        return StereoDiarization(**kwargs)
-    else:
-        raise ValueError(f"Unknown diarization strategy: {strategy}")
+    if strategy == "energy":
+        from verbatim_diarization.stereo import EnergyDiarization
+
+        return EnergyDiarization(**kwargs)
+
+    if strategy == "channel":
+        from verbatim_diarization.channel import ChannelDiarization
+
+        return ChannelDiarization(**kwargs)
+
+    raise ValueError(f"Unknown diarization strategy: {strategy}")

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -108,7 +108,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
                 raise ValueError("Stereo separation requires stereo audio input")
 
             # Create diarization annotation
-            diarizer = create_diarizer(strategy="stereo", device=self.device, huggingface_token=self.huggingface_token)
+            diarizer = create_diarizer(strategy="energy", device=self.device, huggingface_token=self.huggingface_token)
             diarization = diarizer.compute_diarization(
                 file_path=file_path, out_rttm_file=out_rttm_file, out_vttm_file=out_vttm_file, nb_speakers=nb_speakers
             )

--- a/verbatim_diarization/stereo/__init__.py
+++ b/verbatim_diarization/stereo/__init__.py
@@ -1,4 +1,4 @@
-from .diarize import StereoDiarization
+from .diarize import EnergyDiarization
 from .separate import ChannelSeparation
 
-__all__ = ["StereoDiarization", "ChannelSeparation"]
+__all__ = ["EnergyDiarization", "ChannelSeparation"]

--- a/verbatim_diarization/stereo/diarize.py
+++ b/verbatim_diarization/stereo/diarize.py
@@ -11,7 +11,7 @@ from verbatim_rttm import Annotation, AudioRef, Segment, write_vttm
 LOG = logging.getLogger(__name__)
 
 
-class StereoDiarization(DiarizationStrategy):
+class EnergyDiarization(DiarizationStrategy):
     def __init__(self, energy_ratio_threshold: float = 1.18):
         self.energy_ratio_threshold = energy_ratio_threshold
 


### PR DESCRIPTION
This pull request refactors the diarization strategy naming and introduces a new channel-based diarization method. The main changes are the replacement of the old `StereoDiarization` strategy with `EnergyDiarization`, the addition of a new `ChannelDiarization` strategy, and updates throughout the codebase and CLI to support these changes. This improves clarity and flexibility for diarization workflows, allowing users to select between energy-based and channel-based speaker separation.

**Diarization strategy updates:**

* Replaced the `StereoDiarization` class and related references with `EnergyDiarization` across the codebase, including tests, imports, and factory functions. (`tests/diarize/test_stereo_diarization.py` [[1]](diffhunk://#diff-29212eb3edc9dae0c6d23b8640d03821501c0266d435ca7d722cd6bc442e6ee2L14-R19) [[2]](diffhunk://#diff-29212eb3edc9dae0c6d23b8640d03821501c0266d435ca7d722cd6bc442e6ee2L28-R28) [[3]](diffhunk://#diff-29212eb3edc9dae0c6d23b8640d03821501c0266d435ca7d722cd6bc442e6ee2L37-R37); `verbatim_diarization/stereo/__init__.py` [[4]](diffhunk://#diff-f7e00c734499e1d1fcae0af24e988a7a32d3f7bfad4488a7e74d03ef2fac8670L1-R4); `verbatim_diarization/stereo/diarize.py` [[5]](diffhunk://#diff-2f5724a8669fc95814d7f4b0c9ccada8b829c595bf90379f2a9d4d4fd927aeafL14-R14); `verbatim_diarization/diarize/factory.py` [[6]](diffhunk://#diff-ee1c34d31436d4ef2f9f4aa3c17e4e0cd132fa6b2adb754581add5138e3e87c6L52-R62) [[7]](diffhunk://#diff-ee1c34d31436d4ef2f9f4aa3c17e4e0cd132fa6b2adb754581add5138e3e87c6L21-R21); `verbatim_diarization/pyannote/separate.py` [[8]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL111-R111)

* Added a new `ChannelDiarization` strategy that treats each audio channel as a separate speaker, with its own implementation and module. (`verbatim_diarization/channel/diarize.py` [[1]](diffhunk://#diff-bee7efee8ff752dce2a6a3af80226720d34ea0ffff33628241200f46a7c24af2R1-R52); `verbatim_diarization/channel/__init__.py` [[2]](diffhunk://#diff-9efe0d1767732a65807f185742a6202a28c9de898853285725d2a102a17bbb70R1-R3)

**Configuration and CLI improvements:**

* Updated CLI argument choices and help text to support the new strategies: `"pyannote"`, `"energy"`, and `"channel"` (replacing `"stereo"` and `"channels"`). (`verbatim_cli/args.py` [verbatim_cli/args.pyL27-R27](diffhunk://#diff-7c05d3c8bd0c64214ca3e76aa63ca61be6e3a55790b91880a9ffbee8aa459901L27-R27))

* Updated logic throughout `verbatim/audio/sources/factory.py` to use the new strategy names and correctly handle channel preservation for both `"energy"` and `"channel"` strategies. (`verbatim/audio/sources/factory.py` [[1]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L40-R40) [[2]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L109-R112) [[3]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L136-R137) [[4]](diffhunk://#diff-57d6f8fd1619aaa416dbe40539e383f920665e658bfa33becc5b3a9fc17333e0L195-R196)