### PR TITLE
defer downmixing until pyannote strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@
 check: lint type sec
 
 lint:
-	ruff check verbatim tests
-	flake8 verbatim tests
+	ruff check verbatim verbatim_batch verbatim_cli verbatim_diarization verbatim_rttm verbatim_serve verbatim_transcript tests
+	flake8 verbatim verbatim_batch verbatim_cli verbatim_diarization verbatim_rttm verbatim_serve verbatim_transcript tests
 	pylint --disable=import-error verbatim $$(git ls-files 'tests/*.py')
 
 type:
 	pyright
-
+	
 sec:
-	bandit -r verbatim tests run.py
+	bandit -r verbatim verbatim_batch verbatim_cli verbatim_diarization verbatim_rttm verbatim_serve verbatim_transcript tests run.py
 
 # Format code using Ruff formatter
 .PHONY: fmt
@@ -24,7 +24,7 @@ fmt:
 fix:
 	ruff format .
 	ruff check --fix --select I .
-	ruff check --fix verbatim tests
+	ruff check --fix verbatim verbatim_batch verbatim_cli verbatim_diarization verbatim_rttm verbatim_serve verbatim_transcript tests
 
 # Run test suite (quick)
 .PHONY: test

--- a/verbatim/audio/sources/factory.py
+++ b/verbatim/audio/sources/factory.py
@@ -29,6 +29,7 @@ def compute_diarization(
     vttm_file: Optional[str] = None,
     strategy: str = "pyannote",
     nb_speakers: Union[int, None] = None,
+    working_dir: Optional[str] = None,
 ) -> Annotation:
     """
     Compute diarization for an audio file using the specified strategy.
@@ -52,7 +53,13 @@ def compute_diarization(
     )
     diarizer = create_diarizer(strategy=strategy, device=device, huggingface_token=os.getenv("HUGGINGFACE_TOKEN"))
 
-    return diarizer.compute_diarization(file_path=file_path, out_rttm_file=rttm_file, out_vttm_file=vttm_file, nb_speakers=nb_speakers)
+    return diarizer.compute_diarization(
+        file_path=file_path,
+        out_rttm_file=rttm_file,
+        out_vttm_file=vttm_file,
+        nb_speakers=nb_speakers,
+        working_dir=working_dir,
+    )
 
 
 def create_audio_source(
@@ -96,6 +103,7 @@ def create_audio_source(
         source_config.vttm_file = output_prefix_no_ext + ".vttm"
     if source_config.vttm_file == "":
         source_config.vttm_file = None
+    working_dir = os.path.dirname(working_prefix_no_ext) or None
 
     from .ffmpegfileaudiosource import PyAVAudioSource
     from .fileaudiosource import FileAudioSource
@@ -155,6 +163,7 @@ def create_audio_source(
                 vttm_file=source_config.vttm_file,
                 strategy=source_config.diarize_strategy or "pyannote",
                 nb_speakers=nb_speakers,
+                working_dir=working_dir,
             )
         elif source_config.diarization is None:
             LOG.info("Diarization not requested; proceeding without diarization.")
@@ -178,6 +187,7 @@ def create_audio_source(
                     vttm_file=source_config.vttm_file,
                     strategy=source_config.diarize_strategy or "pyannote",
                     nb_speakers=nb_speakers,
+                    working_dir=working_dir,
                 )
 
     if source_config.vttm_file and source_config.diarization is None:

--- a/verbatim_cli/config_file.py
+++ b/verbatim_cli/config_file.py
@@ -5,7 +5,7 @@ import fnmatch
 import json
 from argparse import Namespace
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import yaml
 

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 from typing import List
 

--- a/verbatim_rttm/vttm.py
+++ b/verbatim_rttm/vttm.py
@@ -4,9 +4,9 @@ VTTM: YAML-wrapped RTTM for self-contained diarization + audio references.
 
 import sys
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Tuple
+from typing import Iterable, List, Tuple
 
-from .rttm import Annotation, Segment, loads_rttm, write_rttm
+from .rttm import Annotation, loads_rttm, write_rttm
 
 
 @dataclass


### PR DESCRIPTION
This pull request improves the handling of multi-channel audio for PyAnnote diarization and refines how audio sources are processed based on diarization strategies. The main changes ensure that multi-channel audio is downmixed to mono before being passed to PyAnnote, and that the logic for preserving audio channels is more consistent and explicit across the codebase.

**Audio preprocessing for PyAnnote diarization:**

* Multi-channel audio is now automatically downmixed to mono before running PyAnnote diarization, using `soundfile` and `numpy`. Temporary files are managed and cleaned up after processing. [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7R82-R109) [[2]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7R118-R126)
* Added imports for `numpy` and `tempfile` to support downmixing and temporary file management.

**Audio source factory logic:**

* The condition for preserving audio channels is centralized in a `preserve_for_diarization` variable, ensuring consistent logic throughout `create_audio_source` in `factory.py`.
* When creating a `FileAudioSource`, channel preservation is now explicitly set to `False`, preventing unintended multi-channel handling for diarization strategies that do not require it.