### PR TITLE
Centralize rttm_to_vttm

### DIFF
--- a/verbatim_audio/sources/factory.py
+++ b/verbatim_audio/sources/factory.py
@@ -11,7 +11,7 @@ from verbatim_diarization import create_diarizer  # Add this import
 from verbatim_diarization.policy import assign_channels, parse_params, parse_policy
 from verbatim_diarization.separate import create_separator
 from verbatim_files.rttm import Annotation as RTTMAnnotation
-from verbatim_files.rttm import Segment
+from verbatim_files.rttm import Segment, rttm_to_vttm
 from verbatim_files.vttm import AudioRef, load_vttm, write_vttm
 
 from ..audio import samples_to_seconds, timestr_to_samples
@@ -502,11 +502,10 @@ def create_audio_sources(
                 source_config.diarization = Diarization.load_diarization(rttm_file=source_config.diarization_file)
                 if source_config.vttm_file and source_config.diarization is not None:
                     audio_id = os.path.splitext(os.path.basename(input_source))[0]
-                    # Derive VTTM from RTTM for compatibility
-                    write_vttm(
+                    rttm_to_vttm(
+                        source_config.diarization_file,
                         source_config.vttm_file,
-                        audio=[AudioRef(id=audio_id, path=input_source, channels="1")],
-                        annotation=source_config.diarization,
+                        audio_refs=[AudioRef(id=audio_id, path=input_source, channels="1")],
                     )
             except (StopIteration, FileNotFoundError):
                 # If the file doesn't exist or is empty, compute new diarization

--- a/verbatim_files/__init__.py
+++ b/verbatim_files/__init__.py
@@ -2,7 +2,7 @@
 Transcription/output file utilities: format writers and RTTM/VTTM helpers.
 """
 
-from .rttm import Annotation, Segment, load_rttm, loads_rttm, write_rttm
+from .rttm import Annotation, Segment, load_rttm, loads_rttm, rttm_to_vttm, vttm_to_rttm, write_rttm
 from .vttm import AudioRef, load_vttm, write_vttm
 
 __all__ = [
@@ -12,6 +12,8 @@ __all__ = [
     "load_rttm",
     "load_vttm",
     "loads_rttm",
+    "rttm_to_vttm",
+    "vttm_to_rttm",
     "write_rttm",
     "write_vttm",
 ]


### PR DESCRIPTION
This pull request introduces new helper functions for converting between RTTM and VTTM file formats and refactors existing code to use these helpers for improved clarity and maintainability. It also adds corresponding tests to ensure the correctness of these conversions. The changes are grouped into new feature additions, refactoring for maintainability, and test coverage improvements.

### New features: RTTM/VTTM conversion helpers

* Added `rttm_to_vttm` and `vttm_to_rttm` helper functions in `verbatim_files/rttm.py` to enable direct conversion between RTTM and VTTM formats, including logic for resolving audio references. (_[verbatim_files/rttm.pyR129-R172](diffhunk://#diff-cf34e4f197e8d4fe623ec8b396518e0a1916128e76ca02449434ee395a62e61bR129-R172)_)
* Exported the new conversion helpers in `verbatim_files/__init__.py` for package-wide accessibility. (_[[1]](diffhunk://#diff-399a8f20e8207263d0eace1b2e0388ee1b93474ded706dc59e3361a7c1b0ee7eL5-R5)_, _[[2]](diffhunk://#diff-399a8f20e8207263d0eace1b2e0388ee1b93474ded706dc59e3361a7c1b0ee7eR15-R16)_)

### Refactoring for maintainability

* Refactored `verbatim_audio/sources/factory.py` to use `rttm_to_vttm` for VTTM derivation, replacing manual calls to `write_vttm` and simplifying audio reference handling. (_[[1]](diffhunk://#diff-62faef7ebe5a79d7333ad6d407d2b7addff042269dc0d02909de4ed27d3a6788L14-R14)_, _[[2]](diffhunk://#diff-62faef7ebe5a79d7333ad6d407d2b7addff042269dc0d02909de4ed27d3a6788L505-R508)_)
* Refactored `verbatim_diarization/pyannote/separate.py` to centralize RTTM annotation construction in a new `_build_rttm_annotation` helper, and streamlined writing of RTTM/VTTM files using this approach. (_[[1]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL2-R3)_, _[[2]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcR18-R20)_, _[[3]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcR29-R37)_, _[[4]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL115-R128)_, _[[5]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL143-R169)_)

### Test coverage improvements

* Added tests in `tests/rttm/test_rttm.py` to verify the correctness of the new RTTM-to-VTTM and VTTM-to-RTTM conversion helpers. (_[[1]](diffhunk://#diff-13cba1cec99c93504d579e5a9e116846fc065101907419c57e6f3981fee3d11cL5-R5)_, _[[2]](diffhunk://#diff-13cba1cec99c93504d579e5a9e116846fc065101907419c57e6f3981fee3d11cR62-R86)_)