### PR TITLE
Fix audio ranges

### DIFF
--- a/tests/audio/test_audio.py
+++ b/tests/audio/test_audio.py
@@ -2,6 +2,7 @@ import io
 import math
 import unittest
 import wave
+from typing import cast
 
 import numpy as np
 
@@ -102,7 +103,8 @@ class TestAudioProcessing(unittest.TestCase):
         from verbatim_audio.sources.fileaudiosource import FileAudioSource
 
         buffer = io.BytesIO()
-        with wave.open(buffer, "wb") as wav_file:
+        wav_file = cast(wave.Wave_write, wave.open(buffer, "wb"))
+        with wav_file:
             wav_file.setnchannels(1)
             wav_file.setsampwidth(1)
             wav_file.setframerate(AUDIO_PARAMS.sample_rate)

--- a/tests/audio/test_audio.py
+++ b/tests/audio/test_audio.py
@@ -1,22 +1,46 @@
+import io
 import math
 import unittest
+import wave
 
 import numpy as np
 
+from verbatim.cache import InMemoryArtifactCache
 from verbatim_audio.settings import AUDIO_PARAMS
 
 # pylint: disable=import-outside-toplevel
 
 
 class TestAudioProcessing(unittest.TestCase):
+    def test_constrain_audio_range(self):
+        from verbatim_audio.audio import constrain_audio_range
+
+        audio = np.array([0.0, 1.25, -0.5], dtype=np.float32)
+        output = constrain_audio_range(audio)
+        self.assertEqual(output.dtype, np.float32)
+        self.assertLessEqual(float(np.max(np.abs(output))), 1.0)
+        np.testing.assert_array_almost_equal(output, np.array([0.0, 1.0, -0.5], dtype=np.float32), decimal=5)
+
+    def test_resample_audio_uses_resampling_branch(self):
+        from verbatim_audio.audio import resample_audio
+
+        audio = np.array([0.0, 1.0, 0.0, -1.0], dtype=np.float32)
+        output = resample_audio(audio, from_sampling_rate=8000, to_sampling_rate=16000)
+        self.assertEqual(output.dtype, np.float32)
+        self.assertEqual(output.shape[0], 8)
+
     def test_format_audio(self):
-        from verbatim_audio.audio import format_audio
+        from verbatim_audio.audio import format_audio, to_float32_audio
 
         sample_rate = AUDIO_PARAMS.sample_rate
         audio_mono_float = np.array([0.0, 0.5, -0.5, 1.0, -1.0], dtype=np.float32)
         output = format_audio(audio_mono_float, sample_rate)
         np.testing.assert_array_almost_equal(output, audio_mono_float)
         self.assertEqual(output.dtype, np.float32)
+
+        audio_hot_float = np.array([0.0, 1.25, -1.25], dtype=np.float32)
+        output = format_audio(audio_hot_float, sample_rate)
+        np.testing.assert_array_almost_equal(output, audio_hot_float)
 
         audio_mono_int16 = np.array([0, 16384, -16384, 32767, -32768], dtype=np.int16)
         output = format_audio(audio_mono_int16, sample_rate)
@@ -43,11 +67,19 @@ class TestAudioProcessing(unittest.TestCase):
         audio_short = np.array([0.5], dtype=np.float32)
         output = format_audio(audio_short, from_sampling_rate)
         self.assertEqual(output.size, 0)
-        self.assertEqual(output.dtype, np.int16)
+        self.assertEqual(output.dtype, np.float32)
 
         audio_mono_int8 = np.array([0, 64, -64, 127, -128], dtype=np.int8)
         output = format_audio(audio_mono_int8, sample_rate)
         expected = audio_mono_int8.astype(np.float32) / 128.0
+        np.testing.assert_array_almost_equal(output, expected, decimal=5)
+
+        audio_mono_uint8 = np.array([0, 128, 255], dtype=np.uint8)
+        output = to_float32_audio(audio_mono_uint8)
+        expected = np.array([-1.0, 0.0, 127.0 / 128.0], dtype=np.float32)
+        np.testing.assert_array_almost_equal(output, expected, decimal=5)
+
+        output = format_audio(audio_mono_uint8, sample_rate)
         np.testing.assert_array_almost_equal(output, expected, decimal=5)
 
     def test_wav_to_int16(self):
@@ -65,6 +97,26 @@ class TestAudioProcessing(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             wav_to_int16(np.array([0, 1, 2], dtype=np.uint8))
+
+    def test_file_audio_source_decodes_pcm_u8_wav(self):
+        from verbatim_audio.sources.fileaudiosource import FileAudioSource
+
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(1)
+            wav_file.setframerate(AUDIO_PARAMS.sample_rate)
+            wav_file.writeframes(np.array([0, 128, 255], dtype=np.uint8).tobytes())
+
+        cache = InMemoryArtifactCache()
+        cache.set_bytes("sample.wav", buffer.getvalue())
+        source = FileAudioSource(file="sample.wav", cache=cache, diarization=None)
+
+        with source.open() as stream:
+            output = stream.next_chunk(chunk_length=1)
+
+        expected = np.array([-1.0, 0.0, 127.0 / 128.0], dtype=np.float32)
+        np.testing.assert_array_almost_equal(output, expected, decimal=5)
 
     def test_samples_to_seconds(self):
         from verbatim_audio.audio import samples_to_seconds

--- a/tests/diarize/test_senko_diarize.py
+++ b/tests/diarize/test_senko_diarize.py
@@ -43,6 +43,7 @@ class _FakeDiarizer:
             {
                 "mode": "samples",
                 "samples_len": len(samples),
+                "max_abs": float(np.max(np.abs(samples))) if len(samples) else 0.0,
                 "sample_rate": sample_rate,
                 "accurate": accurate,
                 "generate_colors": generate_colors,
@@ -140,6 +141,24 @@ class TestSenkoDiarization(unittest.TestCase):
         self.assertEqual("samples", _FakeDiarizer.calls[0]["mode"])
         self.assertEqual(16000, _FakeDiarizer.calls[0]["sample_rate"])
         self.assertEqual(16000, _FakeDiarizer.calls[0]["samples_len"])
+
+    def test_normalizes_in_memory_samples_when_peak_exceeds_one(self):
+        fake_senko = types.ModuleType("senko")
+        fake_senko.Diarizer = _FakeDiarizer
+        cache = InMemoryArtifactCache()
+        buffer = io.BytesIO()
+        samples = np.array([0.0, 1.1259971, -0.5, 0.25], dtype=np.float32)
+        sf.write(buffer, samples, 16000, format="WAV", subtype="FLOAT")
+        cache.set_bytes("sample.wav", buffer.getvalue())
+
+        with patch.dict(sys.modules, {"senko": fake_senko}):
+            diarizer = SenkoDiarization(cache=cache, device="cpu")
+            with patch.object(diarizer, "_is_compatible_wav", return_value=False):
+                annotation = diarizer.compute_diarization(file_path="sample.wav")
+
+        self.assertEqual(2, len(annotation.segments))
+        self.assertEqual("samples", _FakeDiarizer.calls[0]["mode"])
+        self.assertLessEqual(_FakeDiarizer.calls[0]["max_abs"], 1.0)
 
     def test_requires_disk_backed_cache_when_in_memory_api_is_unavailable(self):
         class _PathOnlyFakeDiarizer:

--- a/verbatim/non_speech.py
+++ b/verbatim/non_speech.py
@@ -6,6 +6,8 @@ from typing import List, Protocol
 import numpy as np
 from numpy.typing import NDArray
 
+from verbatim_audio.audio import constrain_audio_range
+
 LOG = logging.getLogger(__name__)
 
 DEFAULT_AST_AUDIO_MODEL = "MIT/ast-finetuned-audioset-10-10-0.4593"
@@ -74,11 +76,11 @@ class AstNonSpeechClassifier:
 
     def _resample(self, audio: NDArray[np.float32], sample_rate: int) -> NDArray[np.float32]:
         if sample_rate == TARGET_SR:
-            return audio.astype(np.float32, copy=False)
+            return constrain_audio_range(audio.astype(np.float32, copy=False))
 
         waveform = self._torch.from_numpy(audio.astype(np.float32, copy=False)).unsqueeze(0)
         resampled = self._torchaudio.functional.resample(waveform, sample_rate, TARGET_SR)
-        return resampled.squeeze(0).cpu().numpy().astype(np.float32, copy=False)
+        return constrain_audio_range(resampled.squeeze(0).cpu().numpy().astype(np.float32, copy=False))
 
     @staticmethod
     def _chunk_audio(audio: NDArray[np.float32]) -> List[NDArray[np.float32]]:

--- a/verbatim_audio/audio.py
+++ b/verbatim_audio/audio.py
@@ -11,21 +11,73 @@ from .settings import AUDIO_PARAMS
 LOG = logging.getLogger(__name__)
 
 
+def to_float32_audio(audio: NDArray) -> NDArray:
+    """Convert common PCM/integer audio arrays to float32 full scale."""
+    if audio.dtype == np.float32:
+        return audio.astype(np.float32, copy=False)
+    if audio.dtype == np.uint8:
+        # Unsigned 8-bit PCM is centered at 128, not 0.
+        return (audio.astype(np.float32) - 128.0) / 128.0
+    if audio.dtype == np.int8:
+        return audio.astype(np.float32) / 128.0
+    if audio.dtype == np.int16:
+        return audio.astype(np.float32) / 32768.0
+    if audio.dtype == np.int32:
+        return audio.astype(np.float32) / 2147483648.0
+    return audio.astype(np.float32)
+
+
+def constrain_audio_range(audio: NDArray, *, max_abs_value: float = 1.0) -> NDArray:
+    """Clip float audio to the allowed full-scale range without changing chunk gain."""
+    float_audio = to_float32_audio(np.asarray(audio))
+    if float_audio.size == 0:
+        return float_audio
+
+    return np.clip(float_audio, -max_abs_value, max_abs_value).astype(np.float32, copy=False)
+
+
+def resample_audio(
+    audio: NDArray,
+    from_sampling_rate: int,
+    to_sampling_rate: int,
+    *,
+    method: str = "fft",
+    axis: int = 0,
+) -> NDArray:
+    """Resample audio while preserving the caller's amplitude semantics."""
+    float_audio = to_float32_audio(np.asarray(audio))
+    if float_audio.ndim == 0:
+        float_audio = float_audio.reshape(1)
+
+    if float_audio.size == 0 or from_sampling_rate == to_sampling_rate:
+        return float_audio.astype(np.float32, copy=False)
+
+    norm_axis = axis % float_audio.ndim
+    if method == "fft":
+        # Lazy import to avoid pulling scipy.signal during CLI startup
+        from scipy.signal import resample  # type: ignore  # pylint: disable=import-outside-toplevel
+
+        target_len = int(float_audio.shape[norm_axis] * to_sampling_rate / from_sampling_rate)
+        if target_len == 0:
+            output_shape = list(float_audio.shape)
+            output_shape[norm_axis] = 0
+            return np.empty(output_shape, dtype=np.float32)
+        resampled_audio = resample(float_audio, target_len, axis=norm_axis)
+    elif method == "poly":
+        # Lazy import to avoid pulling scipy.signal during CLI startup
+        from scipy.signal import resample_poly  # type: ignore  # pylint: disable=import-outside-toplevel
+
+        resampled_audio = resample_poly(float_audio, to_sampling_rate, from_sampling_rate, axis=norm_axis)
+    else:
+        raise ValueError(f"Unsupported resample method: {method}")
+
+    return np.asarray(resampled_audio, dtype=np.float32)
+
+
 def format_audio(audio: NDArray, from_sampling_rate: int) -> NDArray:
     to_sampling_rate = AUDIO_PARAMS.sample_rate
 
-    float_audio: NDArray
-    if audio.dtype == np.float32:
-        float_audio = audio
-    else:
-        if audio.dtype == np.int8:
-            float_audio = audio.astype(np.float32) / 128.0
-        elif audio.dtype == np.int16:
-            float_audio = audio.astype(np.float32) / 32768.0
-        elif audio.dtype == np.int32:
-            float_audio = audio.astype(np.float32) / 2147483648.0
-        else:
-            float_audio = audio.astype(np.float32)
+    float_audio: NDArray = to_float32_audio(audio)
 
     # If the audio is stereo, mix it down to mono
     mono_audio: NDArray
@@ -41,15 +93,9 @@ def format_audio(audio: NDArray, from_sampling_rate: int) -> NDArray:
         resampled_audio = mono_audio
     else:
         LOG.debug("Resampling from %s Hz to %s Hz.", from_sampling_rate, to_sampling_rate)
-        # Lazy import to avoid pulling scipy.signal during CLI startup
-        from scipy.signal import resample  # type: ignore  # pylint: disable=import-outside-toplevel
+        resampled_audio = resample_audio(mono_audio, from_sampling_rate, to_sampling_rate)
 
-        num_samples = int(len(mono_audio) * to_sampling_rate / from_sampling_rate)
-        if num_samples == 0:
-            return np.array([], dtype=np.int16)
-        resampled_audio = resample(mono_audio, num_samples)  # pyright: ignore[reportAssignmentType]
-
-    return resampled_audio.astype(np.float32)
+    return resampled_audio.astype(np.float32, copy=False)
 
 
 def wav_to_int16(data):

--- a/verbatim_audio/sources/ffmpegfileaudiosource.py
+++ b/verbatim_audio/sources/ffmpegfileaudiosource.py
@@ -8,7 +8,7 @@ import av
 import numpy as np
 from numpy.typing import NDArray
 
-from ..audio import seconds_to_samples
+from ..audio import resample_audio, seconds_to_samples, to_float32_audio
 from .audiosource import AudioSource, AudioStream
 
 LOG = logging.getLogger(__name__)
@@ -123,8 +123,8 @@ class PyAVAudioStream(AudioStream):
                     self._done_decoding = True
                     break
 
-            # Convert the frame to ndarray, float32
-            arr = frame.to_ndarray().astype(np.float32, copy=False)
+            # Normalize decoded PCM types explicitly instead of relying on PyAV output format details.
+            arr = to_float32_audio(frame.to_ndarray())
 
             # Normalize shape to always be (channels, samples)
             if arr.ndim == 1:
@@ -154,16 +154,9 @@ class PyAVAudioStream(AudioStream):
         if original_sample_rate != target_sample_rate:
             LOG.debug(f"Resampling from {original_sample_rate} → {target_sample_rate} Hz")
 
-            # Resample each channel independently
-            up = int(target_sample_rate)
-            down = int(original_sample_rate)
-
-            # Lazy import to avoid pulling scipy.signal during CLI startup
-            from scipy.signal import resample_poly  # type: ignore  # pylint: disable=import-outside-toplevel
-
             resampled_channels = []
             for ch_idx in range(full_array.shape[0]):
-                resampled = resample_poly(full_array[ch_idx], up, down)
+                resampled = resample_audio(full_array[ch_idx], original_sample_rate, target_sample_rate, method="poly")
                 resampled_channels.append(resampled)
 
             # Stack back into (channels, samples)

--- a/verbatim_audio/sources/fileaudiosource.py
+++ b/verbatim_audio/sources/fileaudiosource.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from verbatim.cache import ArtifactCache
 from verbatim.voices.isolation import VoiceIsolation
 
-from ..audio import format_audio, sample_to_timestr
+from ..audio import format_audio, sample_to_timestr, to_float32_audio
 from ..convert import convert_bytes_to_wav, convert_to_wav
 from .audiosource import AudioSource, AudioStream
 
@@ -89,8 +89,8 @@ class FileAudioStream(AudioStream):
                 LOG.warning("Requested channel indices %s exceed available channels %s", self.channel_indices, n_channels)
                 return np.array([], dtype=np.float32)
 
-        # Convert to float32
-        audio_array = audio_array.astype(np.float32) / 32768.0
+        # Convert PCM samples to float32 using the shared full-scale mapping.
+        audio_array = to_float32_audio(audio_array)
 
         if hasattr(self.source, "preserve_channels") and self.source.preserve_channels:
             # For diarization purposes, return stereo

--- a/verbatim_audio/sources/memoryaudiosource.py
+++ b/verbatim_audio/sources/memoryaudiosource.py
@@ -3,22 +3,10 @@ from typing import Optional
 import numpy as np
 from numpy.typing import NDArray
 
-from ..audio import format_audio
+from ..audio import format_audio, to_float32_audio
 from .audiosource import AudioSource, AudioStream
 
 Annotation = object  # pylint: disable=invalid-name
-
-
-def _to_float32(audio: NDArray) -> NDArray:
-    if audio.dtype == np.float32:
-        return audio
-    if audio.dtype == np.int8:
-        return audio.astype(np.float32) / 128.0
-    if audio.dtype == np.int16:
-        return audio.astype(np.float32) / 32768.0
-    if audio.dtype == np.int32:
-        return audio.astype(np.float32) / 2147483648.0
-    return audio.astype(np.float32)
 
 
 class MemoryAudioStream(AudioStream):
@@ -44,10 +32,10 @@ class MemoryAudioStream(AudioStream):
             return np.array([], dtype=np.float32)
 
         if self.source.preserve_channels:
-            return _to_float32(raw)
+            return to_float32_audio(raw)
 
         # Mix down and resample to target rate via format_audio
-        return format_audio(_to_float32(raw), from_sampling_rate=self.source.sample_rate)
+        return format_audio(to_float32_audio(raw), from_sampling_rate=self.source.sample_rate)
 
     def has_more(self) -> bool:
         end = self.source.end_sample or self.source.total_samples

--- a/verbatim_audio/sources/wavsink.py
+++ b/verbatim_audio/sources/wavsink.py
@@ -4,6 +4,7 @@ import wave
 import numpy as np
 
 from verbatim.cache import ArtifactCache
+from verbatim_audio.audio import constrain_audio_range, resample_audio
 
 from .audiosource import AudioSource
 
@@ -39,11 +40,8 @@ class WavSink:
 
                     # Resample the audio if needed
                     if input_sample_rate != sample_rate:
-                        # Lazy import to avoid pulling scipy.signal during CLI startup
-                        from scipy.signal import resample  # type: ignore  # pylint: disable=import-outside-toplevel
-
-                        target_len = int(len(audio_chunk) * sample_rate / input_sample_rate)
-                        audio_chunk = np.asarray(resample(audio_chunk, target_len))
+                        audio_chunk = resample_audio(audio_chunk, input_sample_rate, sample_rate)
+                    audio_chunk = constrain_audio_range(audio_chunk)
 
                     # Convert to 16-bit PCM
                     int_samples = (audio_chunk * 32767).clip(-32768, 32767).astype(np.int16)

--- a/verbatim_diarization/pyannote/diarize.py
+++ b/verbatim_diarization/pyannote/diarize.py
@@ -15,6 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
+from verbatim_audio.audio import constrain_audio_range
 from verbatim_diarization.diarize.base import DiarizationStrategy
 from verbatim_diarization.pyannote.progress import StatusProgressHook
 from verbatim_diarization.pyannote.separate import PyannoteSpeakerSeparation, _build_rttm_annotation
@@ -91,7 +92,7 @@ class PyAnnoteDiarization(DiarizationStrategy):
                 else:
                     mono = audio
 
-                waveform = torch.from_numpy(np.asarray(mono, dtype=np.float32))
+                waveform = torch.from_numpy(constrain_audio_range(np.asarray(mono, dtype=np.float32)))
                 if waveform.ndim == 1:
                     waveform = waveform.unsqueeze(0)
                 # Feed the pipeline an in-memory waveform directly so pyannote does not need

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -15,7 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
-from verbatim_audio.audio import wav_to_int16
+from verbatim_audio.audio import constrain_audio_range, wav_to_int16
 from verbatim_audio.sources.audiosource import AudioSource
 from verbatim_audio.sources.fileaudiosource import FileAudioSource
 from verbatim_diarization.separate.base import SeparationStrategy
@@ -107,7 +107,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             else:
                 mono = audio
 
-            waveform = torch.from_numpy(np.asarray(mono, dtype=np.float32))
+            waveform = torch.from_numpy(constrain_audio_range(np.asarray(mono, dtype=np.float32)))
             if waveform.ndim == 1:
                 waveform = waveform.unsqueeze(0)
             return {"waveform": waveform, "sample_rate": int(sample_rate)}, None

--- a/verbatim_diarization/senko/diarize.py
+++ b/verbatim_diarization/senko/diarize.py
@@ -7,6 +7,7 @@ import numpy as np
 import soundfile as sf
 
 from verbatim.cache import ArtifactCache, FileBackedArtifactCache
+from verbatim_audio.audio import constrain_audio_range, resample_audio
 from verbatim_audio.convert import convert_bytes_to_wav
 from verbatim_diarization.diarize.base import DiarizationStrategy
 from verbatim_diarization.utils import sanitize_uri_component
@@ -124,11 +125,8 @@ class SenkoDiarization(DiarizationStrategy):
         if samples.ndim > 1:
             samples = samples.mean(axis=1)
         if sample_rate != SENKO_SAMPLE_RATE:
-            from scipy.signal import resample  # type: ignore  # pylint: disable=import-outside-toplevel
-
-            target_len = int(len(samples) * SENKO_SAMPLE_RATE / sample_rate)
-            samples = np.asarray(resample(samples, target_len), dtype=np.float32)
-        return samples.astype(np.float32, copy=False)
+            samples = resample_audio(samples, sample_rate, SENKO_SAMPLE_RATE)
+        return constrain_audio_range(samples)
 
     @staticmethod
     def _segments_to_annotation(segments: List[Dict[str, Any]], *, file_id: str) -> Annotation:


### PR DESCRIPTION
This pull request introduces a unified and robust approach for converting, normalizing, and resampling audio data throughout the codebase. It adds new utility functions in `verbatim_audio/audio.py` for converting audio to float32, constraining audio amplitude, and resampling, and refactors all relevant modules and tests to use these utilities. This improves the consistency and correctness of audio handling, especially for various PCM formats and amplitude normalization.

Key changes include:

**Core audio utilities and normalization:**

* Added `to_float32_audio`, `constrain_audio_range`, and `resample_audio` functions to `verbatim_audio/audio.py` for standardized audio type conversion, amplitude normalization, and resampling. All audio sources and sinks now use these utilities for consistent handling of PCM and float formats. [[1]](diffhunk://#diff-3ae12cc87e59e830057f46e0fe9ad2a75e7bb7a2ea49af8bfcfa89bdbf0743ddL14-R80) [[2]](diffhunk://#diff-3ae12cc87e59e830057f46e0fe9ad2a75e7bb7a2ea49af8bfcfa89bdbf0743ddL44-R98) [[3]](diffhunk://#diff-2ff486faef8306c4293e0b8cb7ec35b20a5d4d314fba3c32da1a24da549b5e7eR7) [[4]](diffhunk://#diff-2ff486faef8306c4293e0b8cb7ec35b20a5d4d314fba3c32da1a24da549b5e7eL42-R44) [[5]](diffhunk://#diff-95dc4c6e67a10c4cf7c207ceba1c5cc7cceac8aa9d17f3212843e2cd282103d9L11-R11) [[6]](diffhunk://#diff-95dc4c6e67a10c4cf7c207ceba1c5cc7cceac8aa9d17f3212843e2cd282103d9L126-R127) [[7]](diffhunk://#diff-95dc4c6e67a10c4cf7c207ceba1c5cc7cceac8aa9d17f3212843e2cd282103d9L157-R159) [[8]](diffhunk://#diff-67c8ef1fe50e8b8b3695eda7659295d2e71c4162ff06bf9f44fab5a22ba3d8a3L13-R13) [[9]](diffhunk://#diff-67c8ef1fe50e8b8b3695eda7659295d2e71c4162ff06bf9f44fab5a22ba3d8a3L92-R93) [[10]](diffhunk://#diff-f9633b8996622190f57b70cabbf0ea65675dec580d8db2f95121758348aec18bL6-L23) [[11]](diffhunk://#diff-f9633b8996622190f57b70cabbf0ea65675dec580d8db2f95121758348aec18bL47-R38)

* Updated normalization logic in diarization and non-speech detection modules to use `constrain_audio_range`, ensuring input audio is always within the valid range. [[1]](diffhunk://#diff-ab5695a279080a17e44532d3272d341d48db2cf87cf2fa8ce67104745fbe240bR9-R10) [[2]](diffhunk://#diff-ab5695a279080a17e44532d3272d341d48db2cf87cf2fa8ce67104745fbe240bL77-R83) [[3]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7R18) [[4]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7L94-R95) [[5]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL18-R18) [[6]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL110-R110)

**Testing improvements:**

* Expanded and updated tests in `tests/audio/test_audio.py` to cover new utility functions, including tests for unsigned 8-bit PCM conversion, amplitude normalization, and resampling. [[1]](diffhunk://#diff-164257586298a9a5bc2758bfe469051883a9e34133f84ad898af8ec1fc7d1dbfR1-R44) [[2]](diffhunk://#diff-164257586298a9a5bc2758bfe469051883a9e34133f84ad898af8ec1fc7d1dbfL46-R84) [[3]](diffhunk://#diff-164257586298a9a5bc2758bfe469051883a9e34133f84ad898af8ec1fc7d1dbfR101-R120)

* Added a new test to `tests/diarize/test_senko_diarize.py` to verify normalization of in-memory samples when peak amplitude exceeds one, and to track maximum absolute value in diarization calls. [[1]](diffhunk://#diff-56a1cd6bb2ce91029fc7e4ab0c3a3cdb9215cda13cb19050617a3f137dfc8290R46) [[2]](diffhunk://#diff-56a1cd6bb2ce91029fc7e4ab0c3a3cdb9215cda13cb19050617a3f137dfc8290R145-R162)

**Refactoring and code cleanup:**

* Removed ad-hoc or duplicated audio conversion code from audio sources and replaced with standardized utility calls, reducing code duplication and potential for errors. [[1]](diffhunk://#diff-f9633b8996622190f57b70cabbf0ea65675dec580d8db2f95121758348aec18bL6-L23) [[2]](diffhunk://#diff-f9633b8996622190f57b70cabbf0ea65675dec580d8db2f95121758348aec18bL47-R38) [[3]](diffhunk://#diff-67c8ef1fe50e8b8b3695eda7659295d2e71c4162ff06bf9f44fab5a22ba3d8a3L92-R93) [[4]](diffhunk://#diff-95dc4c6e67a10c4cf7c207ceba1c5cc7cceac8aa9d17f3212843e2cd282103d9L126-R127) [[5]](diffhunk://#diff-95dc4c6e67a10c4cf7c207ceba1c5cc7cceac8aa9d17f3212843e2cd282103d9L157-R159)

These changes make audio data handling more robust and predictable across the codebase.