### PR TITLE
updated the env and switch naming scheme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
           VERBATIM_OFFLINE: "0"
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
         run: |
-          verbatim --install --model-cache "$GITHUB_WORKSPACE/.verbatim"
+          verbatim --install --modeldir "$GITHUB_WORKSPACE/.verbatim"
 
       - name: Run quick tests (exclude markers)
         shell: bash
@@ -168,7 +168,7 @@ jobs:
           VERBATIM_OFFLINE: "0"
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
         run: |
-          verbatim --install --model-cache "$GITHUB_WORKSPACE/.verbatim"
+          verbatim --install --modeldir "$GITHUB_WORKSPACE/.verbatim"
 
       - name: Create .coveragerc
         shell: bash

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Install Senko separately when you want the optional Senko diarization backend:
 uv pip install "git+https://github.com/narcotic-sh/senko.git"
 ```
 
-Encrypted DS2 files can be opened with `password:` in a YAML/JSON config file or the `VERBATIM_DSS_PASSWORD` environment variable. A `--password` switch is also available, but it is less safe because it can leak secrets via shell history and process listings.
+Encrypted DS2 files can be opened with `password:` in a YAML/JSON config file or the `VERBATIM_AUDIO_PASSWORD` environment variable. A `--password` switch is also available, but it is less safe because it can leak secrets via shell history and process listings.
 
 Recommended:
 ```bash
-VERBATIM_DSS_PASSWORD=1234 verbatim recording.ds2 --txt
+VERBATIM_AUDIO_PASSWORD=1234 verbatim recording.ds2 --txt
 ```
 
 When using a Senko build that supports in-memory diarization, Verbatim can also run Senko without a working directory by feeding cached 16kHz mono samples directly into the diarizer. This is useful for server deployments that must avoid writing intermediate files.
@@ -133,6 +133,11 @@ Force CPU only
 verbatim audio_file.mp3 --cpu
 ```
 
+Select device explicitly
+```bash
+verbatim audio_file.mp3 --device cuda
+```
+
 Save file in a specific directory
 ```bash
 verbatim audio_file.mp3 -o ./output/
@@ -151,25 +156,43 @@ verbatim-batch --batch-dir ./audio --match "*.wav" "*.mp3" "*.dss" "*.ds2" --rec
 Backend selection examples
 ```bash
 # Run Qwen ASR explicitly
-verbatim audio_file.wav --transcriber-backend qwen --languages en fr
+verbatim audio_file.wav --asr-backend qwen --languages en fr
 
 # Run Qwen ASR with MMS language identification
-verbatim audio_file.wav --transcriber-backend qwen --language-identifier-backend mms --languages en fr
+verbatim audio_file.wav --asr-backend qwen --language-backend mms --language-model facebook/mms-lid-126 --languages en fr
 
 # On Apple Silicon, Qwen will use MPS automatically unless you force --cpu
-verbatim audio_file.wav --transcriber-backend qwen --language-identifier-backend mms --languages en fr -v
+verbatim audio_file.wav --asr-backend qwen --language-backend mms --language-model facebook/mms-lid-126 --languages en fr -v
 
 # Label long skipped non-speech regions with the optional AST classifier
-verbatim audio_file.wav --transcriber-backend qwen --language-identifier-backend mms --languages en fr --non-speech-backend ast -vv
+verbatim audio_file.wav --asr-backend qwen --language-backend mms --language-model facebook/mms-lid-126 --languages en fr --non-vad-backend ast --noise-model MIT/ast-finetuned-audioset-10-10-0.4593 -vv
 ```
+
+Equivalent environment variables
+```bash
+VERBATIM_ASR_BACKEND=qwen
+VERBATIM_LANGUAGE_BACKEND=mms
+VERBATIM_LANGUAGE_MODEL=facebook/mms-lid-126
+VERBATIM_DIARIZE=senko
+VERBATIM_ASR_MODEL=Qwen/Qwen3-ASR-1.7B
+VERBATIM_DEVICE=cuda
+VERBATIM_VAD_BACKEND=ast
+VERBATIM_NOISE_MODEL=MIT/ast-finetuned-audioset-10-10-0.4593
+VERBATIM_VOXTRAL_MAX_NEW_TOKENS=512
+VERBATIM_CODE_SWITCHING=false
+```
+
+Precedence is `CLI > config file > environment variable > default`.
+
+`--cpu` is a shorthand for `--device cpu`. When `--device cuda` or `VERBATIM_DEVICE=cuda` is requested explicitly, Verbatim now fails fast if CUDA is unavailable.
 
 Long-skip review markers
 ```bash
 # Default energy-based labels for long skipped regions (for example [SILENCE] or [ENVIRONMENT NOISE])
-verbatim audio_file.wav --transcriber-backend qwen --language-identifier-backend mms --languages en fr
+verbatim audio_file.wav --asr-backend qwen --language-backend mms --languages en fr
 
 # Optional AST-based labels for long skipped regions (for example [MUSIC] when the classifier is confident)
-verbatim audio_file.wav --transcriber-backend qwen --language-identifier-backend mms --languages en fr --non-speech-backend ast
+verbatim audio_file.wav --asr-backend qwen --language-backend mms --languages en fr --non-vad-backend ast --noise-model MIT/ast-finetuned-audioset-10-10-0.4593
 ```
 
 Diarization policy examples
@@ -625,26 +648,32 @@ A direct use of whisper on an audio clip like this one results in many errors. S
 
 Verbatim can prefetch and reuse models from a deterministic cache directory, and can run 100% offline once the cache is warmed.
 
-- `--model-cache <dir>`: sets a shared cache directory used by Hugging Face and faster-whisper.
+- `--modeldir <dir>`: sets a shared model/cache directory used by Hugging Face and faster-whisper.
 - `--offline`: prevents any network access and model downloads. All models must already be present in the cache; otherwise a clear error is raised.
-- `--install`: prefetches commonly used models into the selected cache and exits.
+- `--install`: prefetches the models required by the current effective configuration into the selected cache and exits.
 
 Examples
 
-1) Prefetch models (first run, with network):
+1) Prefetch models for the exact configuration you plan to run offline:
 ```
-HUGGINGFACE_TOKEN=hf_... verbatim --install --model-cache /models
-```
-
-2) Fully offline run reusing the cache:
-```
-verbatim input.mp3 -o out --model-cache /models --offline
+HUGGINGFACE_TOKEN=hf_... verbatim input.mp3 --modeldir /models --asr-backend qwen --language-backend mms --install
 ```
 
-Default cache location (when `--model-cache` is not specified):
+2) Fully offline run reusing the same configuration and cache:
+```
+verbatim input.mp3 -o out --modeldir /models --asr-backend qwen --language-backend mms --offline
+```
+
+The offline guarantee is configuration-specific: warm the cache with the same effective CLI/config/env settings that you plan to reuse offline. This includes transitive runtime dependencies such as MMS language identification for Voxtral, AST noise classification, SaT sentence tokenization for non-stream runs, and pyannote diarization/separation when selected.
+
+Default cache location (when `--modeldir` is not specified):
 - Local project directory `./.verbatim/` is used as the root cache.
 - Subdirectories are created inside: `./.verbatim/hf`, `./.verbatim/whisper`, etc.
 - If `./.verbatim/` cannot be created or is not writable, the app gracefully falls back to library defaults.
 
 Voice isolation (MDX): the `audio-separator` backend loads a checkpoint (e.g., `MDX23C-8KFFT-InstVoc_HQ_2.ckpt`).
-For offline use with `--model-cache`, place the file under `<cache>/audio-separator/`.
+When `--isolate` is part of the installed configuration, Verbatim now prefetches that checkpoint into `<cache>/audio-separator/`.
+
+Pyannote diarization/separation still requires `HUGGINGFACE_TOKEN` during `--install` if the selected configuration uses those backends and the models are not yet cached. Once cached, offline reuse does not require the token.
+
+Senko is intentionally excluded from the hard offline-install guarantee for now because its own warmup/download behavior is managed by the upstream package rather than Verbatim.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,8 +1,14 @@
 batch_dir: "./input/"
 
-#transcriber_backend: qwen
-#language_identifier_backend: mms
-#mms_lid_model_size: facebook/mms-lid-126
+#device: auto
+#asr_backend: qwen
+#language_backend: mms
+#language_model: facebook/mms-lid-126
+#asr_model: Qwen/Qwen3-ASR-1.7B
+#vad_backend: ast
+#noise_model: MIT/ast-finetuned-audioset-10-10-0.4593
+#voxtral_max_new_tokens: 512
+#code_switching: false
 
 include:
   filename: ["*.wav", "*.mp3", "*.m4a"]

--- a/doc/airfrance-comparison.md
+++ b/doc/airfrance-comparison.md
@@ -33,9 +33,9 @@ The goal is to compare backend quality and the effect of Verbatim's code-switchi
   --json `
   --outdir out\airfrance_whisper_mms_naive `
   --workdir out\airfrance_whisper_mms_naive_work `
-  --transcriber-backend auto `
-  --language-identifier-backend mms `
-  --mms-lid-model-size facebook/mms-lid-126 `
+  --asr-backend auto `
+  --language-backend mms `
+  --language-model facebook/mms-lid-126 `
   --log-file out\airfrance_whisper_mms_naive_clean.log
 ```
 
@@ -51,9 +51,9 @@ The goal is to compare backend quality and the effect of Verbatim's code-switchi
   --json `
   --outdir out\airfrance_whisper_mms `
   --workdir out\airfrance_whisper_mms_work `
-  --transcriber-backend auto `
-  --language-identifier-backend mms `
-  --mms-lid-model-size facebook/mms-lid-126 `
+  --asr-backend auto `
+  --language-backend mms `
+  --language-model facebook/mms-lid-126 `
   --log-file out\airfrance_whisper_mms_clean.log
 ```
 
@@ -70,9 +70,9 @@ The goal is to compare backend quality and the effect of Verbatim's code-switchi
   --json `
   --outdir out\airfrance_qwen_mms_naive `
   --workdir out\airfrance_qwen_mms_naive_work `
-  --transcriber-backend qwen `
-  --language-identifier-backend mms `
-  --mms-lid-model-size facebook/mms-lid-126 `
+  --asr-backend qwen `
+  --language-backend mms `
+  --language-model facebook/mms-lid-126 `
   --log-file out\airfrance_qwen_mms_naive_clean.log
 ```
 
@@ -88,9 +88,9 @@ The goal is to compare backend quality and the effect of Verbatim's code-switchi
   --json `
   --outdir out\airfrance_qwen_mms `
   --workdir out\airfrance_qwen_mms_work `
-  --transcriber-backend qwen `
-  --language-identifier-backend mms `
-  --mms-lid-model-size facebook/mms-lid-126 `
+  --asr-backend qwen `
+  --language-backend mms `
+  --language-model facebook/mms-lid-126 `
   --log-file out\airfrance_qwen_mms_clean.log
 ```
 

--- a/doc/verbatim-cli.md
+++ b/doc/verbatim-cli.md
@@ -49,6 +49,7 @@ If no input file is provided, Verbatim expects input from stdin or can use the m
 - `--md`: Enable Markdown output
 
 #### Performance & Debugging
+- `--device <auto|cpu|cuda|mps>`: Select the execution device explicitly
 - `--cpu`: Force CPU usage
 - `-s, --stream`: Enable low latency streaming mode
 - `-v, --verbose`: Increase verbosity (use multiple times for more detail)
@@ -93,6 +94,11 @@ verbatim input.wav --md --json --docx
 ### Adjusting Processing Performance
 ```
 verbatim input.wav -b 12 --cpu
+```
+
+### Select Device Explicitly
+```
+verbatim input.wav --device cuda
 ```
 
 ## Exit Codes

--- a/tests/test_batch_match.py
+++ b/tests/test_batch_match.py
@@ -2,7 +2,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from verbatim_batch.main import filter_input_files, iter_input_files
+from verbatim_batch.main import build_batch_parser, collect_install_targets, filter_input_files, iter_input_files
+from verbatim_cli.config_file import select_profile
 
 
 class TestBatchMatch(unittest.TestCase):
@@ -42,6 +43,44 @@ class TestBatchMatch(unittest.TestCase):
             filtered = filter_input_files([kept, skipped], ["archive/*"], batch_dir=base)
 
         self.assertEqual([path.name for path in filtered], ["keep.ds2"])
+
+    def test_collect_install_targets_uses_union_of_matched_profiles(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            wav_path = base / "sample.wav"
+            mp3_path = base / "sample.mp3"
+            wav_path.write_bytes(b"wav")
+            mp3_path.write_bytes(b"mp3")
+
+            cfg_data = {
+                "batch_dir": str(base),
+                "profiles": [
+                    {"include": {"filename": ["*.wav"]}, "asr_backend": "qwen"},
+                    {"include": {"filename": ["*.mp3"]}, "asr_backend": "voxtral", "diarize": "pyannote"},
+                ],
+            }
+            parser = build_batch_parser()
+            base_defaults = parser.parse_args([])
+            user_args = parser.parse_args(["--batch-dir", str(base)])
+            global_profile = select_profile(cfg_data, filename=None)
+
+            targets = collect_install_targets(
+                base_defaults=base_defaults,
+                user_args=user_args,
+                cfg_data=cfg_data,
+                global_profile=global_profile,
+                inputs=[wav_path, mp3_path],
+            )
+
+        backends = sorted(config.transcriber_backend for config, _source_config in targets)
+        diarize_strategies = sorted(
+            source_config.diarize_strategy for _config, source_config in targets if source_config.diarize_strategy is not None
+        )
+
+        self.assertIn("auto", backends)
+        self.assertIn("qwen", backends)
+        self.assertIn("voxtral", backends)
+        self.assertEqual(["pyannote"], diarize_strategies)
 
 
 if __name__ == "__main__":

--- a/tests/test_config_file_legacy.py
+++ b/tests/test_config_file_legacy.py
@@ -1,0 +1,27 @@
+import unittest
+
+from verbatim_cli.config_file import find_legacy_config_keys
+
+
+class TestLegacyConfigWarnings(unittest.TestCase):
+    def test_find_legacy_config_keys_detects_root_and_profile_entries(self):
+        config_data = {
+            "transcriber_backend": "qwen",
+            "profiles": [
+                {
+                    "include": {"filename": ["*.wav"]},
+                    "language_identifier_backend": "mms",
+                    "mms_lid_model_size": "facebook/mms-lid-126",
+                }
+            ],
+        }
+
+        findings = find_legacy_config_keys(config_data)
+
+        self.assertIn(("transcriber_backend", "asr_backend"), findings)
+        self.assertIn(("profiles[0].language_identifier_backend", "language_backend"), findings)
+        self.assertIn(("profiles[0].mms_lid_model_size", "language_model"), findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dss_password_config.py
+++ b/tests/test_dss_password_config.py
@@ -48,7 +48,7 @@ class TestDssPasswordConfig(unittest.TestCase):
             vttm=None,
         )
 
-        with patch.dict(os.environ, {"VERBATIM_DSS_PASSWORD": env_value}, clear=False):
+        with patch.dict(os.environ, {"VERBATIM_AUDIO_PASSWORD": env_value}, clear=False):
             source_config = make_source_config(args, speakers=None)
 
         self.assertEqual(source_config.password, env_value)

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -217,6 +217,11 @@ class TestEnvConfig(unittest.TestCase):
         self.assertEqual(config.ast_audio_model_size, "acme/noise-model")
         self.assertFalse(config.code_switching)
 
+    def test_legacy_model_cache_alias_maps_to_modeldir(self):
+        _parser, _base_defaults, args = self._build_args(["input.wav", "--model-cache", "D:/models"])
+
+        self.assertEqual(args.modeldir, "D:/models")
+
     def test_cli_beats_env_for_vad_and_noise_knobs(self):
         _parser, base_defaults, user_args = self._build_args(
             [

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,265 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from verbatim.config import Config
+from verbatim_cli.args import build_parser
+from verbatim_cli.config_file import load_config_file, merge_args, select_profile
+from verbatim_cli.configure import apply_env_defaults, make_config, make_source_config, resolve_log_level, resolve_status_verbose
+
+
+class TestEnvConfig(unittest.TestCase):
+    @staticmethod
+    def _build_args(argv):
+        parser = build_parser(prog="verbatim")
+        base_defaults = parser.parse_args([])
+        user_args = parser.parse_args(argv)
+        return parser, base_defaults, user_args
+
+    @staticmethod
+    def _write_config(contents: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8") as handle:
+            handle.write(contents)
+            return handle.name
+
+    def test_env_backends_are_used_when_cli_and_config_are_unset(self):
+        _parser, base_defaults, args = self._build_args(["input.wav"])
+
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_ASR_BACKEND": "qwen",
+                "VERBATIM_LANGUAGE_BACKEND": "mms",
+                "VERBATIM_LANGUAGE_MODEL": "facebook/mms-lid-126",
+                "VERBATIM_DIARIZE": "senko",
+                "VERBATIM_ASR_MODEL": "Qwen/Qwen3-ASR-1.7B",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+            source_config = make_source_config(args, speakers=None)
+
+        self.assertEqual(config.transcriber_backend, "qwen")
+        self.assertEqual(config.language_identifier_backend, "mms")
+        self.assertEqual(config.mms_lid_model_size, "facebook/mms-lid-126")
+        self.assertEqual(config.qwen_asr_model_size, "Qwen/Qwen3-ASR-1.7B")
+        self.assertEqual(source_config.diarize_strategy, "senko")
+
+    def test_asr_model_targets_voxtral_when_voxtral_backend_is_selected(self):
+        _parser, base_defaults, args = self._build_args(["input.wav"])
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_ASR_BACKEND": "voxtral",
+                "VERBATIM_ASR_MODEL": "mistralai/Voxtral-Mini-3B-2507",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+
+        self.assertEqual(config.transcriber_backend, "voxtral")
+        self.assertEqual(config.voxtral_model_size, "mistralai/Voxtral-Mini-3B-2507")
+
+    def test_config_file_beats_env_backends(self):
+        _parser, base_defaults, user_args = self._build_args(["input.wav"])
+        config_path = self._write_config(
+            "\n".join(
+                [
+                    "asr_backend: voxtral",
+                    "language_backend: transcriber",
+                    "language_model: acme/mms-custom",
+                    "asr_model: config/asr-model",
+                    "diarize: pyannote",
+                ]
+            )
+            + "\n"
+        )
+
+        try:
+            cfg_data = load_config_file(config_path)
+            profile_overrides = select_profile(cfg_data, filename="input.wav")
+            args = merge_args(base_defaults, profile_overrides, user_args)
+        finally:
+            Path(config_path).unlink()
+
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_ASR_BACKEND": "qwen",
+                "VERBATIM_LANGUAGE_BACKEND": "mms",
+                "VERBATIM_LANGUAGE_MODEL": "facebook/mms-lid-126",
+                "VERBATIM_DIARIZE": "senko",
+                "VERBATIM_ASR_MODEL": "env/asr-model",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+            source_config = make_source_config(args, speakers=None)
+
+        self.assertEqual(config.transcriber_backend, "voxtral")
+        self.assertEqual(config.language_identifier_backend, "transcriber")
+        self.assertEqual(config.mms_lid_model_size, "acme/mms-custom")
+        self.assertEqual(config.voxtral_model_size, "config/asr-model")
+        self.assertEqual(config.whisper_model_size, "large-v3")
+        self.assertEqual(source_config.diarize_strategy, "pyannote")
+
+    def test_cli_beats_config_file_and_env_backends(self):
+        _parser, base_defaults, user_args = self._build_args(
+            [
+                "input.wav",
+                "--asr-backend",
+                "qwen",
+                "--language-backend",
+                "mms",
+                "--language-model",
+                "cli/mms-model",
+                "--asr-model",
+                "cli/asr-model",
+                "--diarize",
+                "senko",
+            ]
+        )
+        config_path = self._write_config(
+            "\n".join(
+                [
+                    "asr_backend: voxtral",
+                    "language_backend: transcriber",
+                    "language_model: config/mms-model",
+                    "asr_model: config/asr-model",
+                    "diarize: pyannote",
+                ]
+            )
+            + "\n"
+        )
+
+        try:
+            cfg_data = load_config_file(config_path)
+            profile_overrides = select_profile(cfg_data, filename="input.wav")
+            args = merge_args(base_defaults, profile_overrides, user_args)
+        finally:
+            Path(config_path).unlink()
+
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_ASR_BACKEND": "auto",
+                "VERBATIM_LANGUAGE_BACKEND": "transcriber",
+                "VERBATIM_LANGUAGE_MODEL": "env/mms-model",
+                "VERBATIM_DIARIZE": "pyannote",
+                "VERBATIM_ASR_MODEL": "env/asr-model",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+            source_config = make_source_config(args, speakers=None)
+
+        self.assertEqual(config.transcriber_backend, "qwen")
+        self.assertEqual(config.language_identifier_backend, "mms")
+        self.assertEqual(config.mms_lid_model_size, "cli/mms-model")
+        self.assertEqual(config.qwen_asr_model_size, "cli/asr-model")
+        self.assertEqual(source_config.diarize_strategy, "senko")
+
+    def test_diarize_policy_beats_env_strategy(self):
+        _parser, base_defaults, args = self._build_args(
+            [
+                "input.wav",
+                "--diarize-policy",
+                "1,2=energy;3=pyannote;*=channel",
+            ]
+        )
+
+        with patch.dict(os.environ, {"VERBATIM_DIARIZE": "senko"}, clear=False):
+            args = apply_env_defaults(args, base_defaults)
+            source_config = make_source_config(args, speakers=None)
+
+        self.assertEqual(source_config.diarize_strategy, "1,2=energy;3=pyannote;*=channel")
+
+    def test_env_defaults_cover_runtime_knobs(self):
+        _parser, base_defaults, args = self._build_args(["input.wav"])
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_MODELDIR": "D:/models",
+                "VERBATIM_OFFLINE": "true",
+                "VERBATIM_WORKDIR": "D:/workdir",
+                "VERBATIM_LOG_FILE": "D:/logs/verbatim.log",
+                "VERBATIM_OUTDIR": "D:/output",
+                "VERBATIM_LOG_LEVEL": "INFO",
+                "VERBATIM_DEVICE": "cpu",
+                "VERBATIM_VOXTRAL_MAX_NEW_TOKENS": "512",
+                "VERBATIM_VAD_BACKEND": "ast",
+                "VERBATIM_NOISE_MODEL": "acme/noise-model",
+                "VERBATIM_CODE_SWITCHING": "false",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+            log_level = resolve_log_level(args, base_defaults)
+            status_verbose = resolve_status_verbose(args, base_defaults)
+
+        self.assertEqual(args.outdir, "D:/output")
+        self.assertEqual(args.log_file, "D:/logs/verbatim.log")
+        self.assertEqual(config.model_cache_dir, "D:/models")
+        self.assertEqual(config.device, "cpu")
+        self.assertTrue(config.offline)
+        self.assertEqual(config.working_dir, "D:/workdir")
+        self.assertEqual(log_level, 20)
+        self.assertEqual(status_verbose, 1)
+        self.assertEqual(config.voxtral_max_new_tokens, 512)
+        self.assertEqual(config.non_speech_backend, "ast")
+        self.assertEqual(config.ast_audio_model_size, "acme/noise-model")
+        self.assertFalse(config.code_switching)
+
+    def test_cli_beats_env_for_vad_and_noise_knobs(self):
+        _parser, base_defaults, user_args = self._build_args(
+            [
+                "input.wav",
+                "--non-vad-backend",
+                "ast",
+                "--noise-model",
+                "cli/noise-model",
+                "--code-switching",
+                "false",
+            ]
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "VERBATIM_VAD_BACKEND": "energy",
+                "VERBATIM_NOISE_MODEL": "env/noise-model",
+                "VERBATIM_CODE_SWITCHING": "true",
+            },
+            clear=False,
+        ):
+            args = apply_env_defaults(user_args, base_defaults)
+            config = make_config(args)
+
+        self.assertEqual(config.non_speech_backend, "ast")
+        self.assertEqual(config.ast_audio_model_size, "cli/noise-model")
+        self.assertFalse(config.code_switching)
+
+    def test_cpu_switch_overrides_device_env(self):
+        _parser, base_defaults, user_args = self._build_args(["input.wav", "--cpu"])
+
+        with patch.dict(os.environ, {"VERBATIM_DEVICE": "cuda"}, clear=False):
+            args = apply_env_defaults(user_args, base_defaults)
+            config = make_config(args)
+
+        self.assertEqual(config.device, "cpu")
+
+    def test_explicit_unavailable_device_fails_fast(self):
+        with patch.object(Config, "is_device_supported", return_value=False):
+            with self.assertRaisesRegex(RuntimeError, "Requested device 'cuda' is not available"):
+                Config(device="cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -260,6 +260,23 @@ class TestEnvConfig(unittest.TestCase):
 
         self.assertEqual(config.device, "cpu")
 
+    def test_config_explicit_default_value_beats_env_override(self):
+        _parser, base_defaults, user_args = self._build_args(["input.wav"])
+        config_path = self._write_config("offline: false\n")
+
+        try:
+            cfg_data = load_config_file(config_path)
+            profile_overrides = select_profile(cfg_data, filename="input.wav")
+            args = merge_args(base_defaults, profile_overrides, user_args)
+        finally:
+            Path(config_path).unlink()
+
+        with patch.dict(os.environ, {"VERBATIM_OFFLINE": "true"}, clear=False):
+            args = apply_env_defaults(args, base_defaults)
+            config = make_config(args)
+
+        self.assertFalse(config.offline)
+
     def test_explicit_unavailable_device_fails_fast(self):
         with patch.object(Config, "is_device_supported", return_value=False):
             with self.assertRaisesRegex(RuntimeError, "Requested device 'cuda' is not available"):

--- a/tests/test_install_prefetch.py
+++ b/tests/test_install_prefetch.py
@@ -1,7 +1,9 @@
+import os
 import unittest
+from unittest.mock import patch
 
 from verbatim.config import Config
-from verbatim.prefetch import collect_install_requirements
+from verbatim.prefetch import apply_cache_env, collect_install_requirements
 from verbatim_audio.sources.sourceconfig import SourceConfig
 
 
@@ -69,6 +71,26 @@ class TestInstallRequirements(unittest.TestCase):
         requirements = collect_install_requirements(config=config, source_config=source_config)
 
         self.assertTrue(requirements.include_isolation)
+
+    def test_apply_cache_env_replaces_hf_cache_paths_between_targets(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "HF_HOME": "C:/old/hf",
+                "HUGGINGFACE_HUB_CACHE": "C:/old/hf/hub",
+                "XDG_CACHE_HOME": "C:/old/xdg",
+            },
+            clear=False,
+        ):
+            apply_cache_env("D:/models-a", offline=False)
+            self.assertEqual(os.environ["HF_HOME"].replace("\\", "/"), "D:/models-a/hf")
+            self.assertEqual(os.environ["HUGGINGFACE_HUB_CACHE"].replace("\\", "/"), "D:/models-a/hf/hub")
+            self.assertEqual(os.environ["XDG_CACHE_HOME"].replace("\\", "/"), "D:/models-a/xdg")
+
+            apply_cache_env("D:/models-b", offline=False)
+            self.assertEqual(os.environ["HF_HOME"].replace("\\", "/"), "D:/models-b/hf")
+            self.assertEqual(os.environ["HUGGINGFACE_HUB_CACHE"].replace("\\", "/"), "D:/models-b/hf/hub")
+            self.assertEqual(os.environ["XDG_CACHE_HOME"].replace("\\", "/"), "D:/models-b/xdg")
 
 
 if __name__ == "__main__":

--- a/tests/test_install_prefetch.py
+++ b/tests/test_install_prefetch.py
@@ -1,0 +1,75 @@
+import unittest
+
+from verbatim.config import Config
+from verbatim.prefetch import collect_install_requirements
+from verbatim_audio.sources.sourceconfig import SourceConfig
+
+
+class TestInstallRequirements(unittest.TestCase):
+    def test_default_whisper_install_includes_sat_and_whisper(self):
+        config = Config(device="cpu")
+        source_config = SourceConfig()
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertTrue(requirements.include_sat)
+        self.assertTrue(requirements.include_faster_whisper)
+        self.assertFalse(requirements.include_qwen_asr)
+        self.assertFalse(requirements.include_voxtral)
+        self.assertFalse(requirements.include_mms_language_model)
+
+    def test_qwen_mms_ast_install_includes_transitive_models(self):
+        config = Config(device="cpu")
+        config.transcriber_backend = "qwen"
+        config.language_identifier_backend = "mms"
+        config.non_speech_backend = "ast"
+        source_config = SourceConfig()
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertTrue(requirements.include_sat)
+        self.assertTrue(requirements.include_qwen_asr)
+        self.assertTrue(requirements.include_mms_language_model)
+        self.assertTrue(requirements.include_ast_noise_model)
+        self.assertFalse(requirements.include_faster_whisper)
+
+    def test_voxtral_transcriber_backend_pulls_in_mms_fallback(self):
+        config = Config(device="cpu")
+        config.transcriber_backend = "voxtral"
+        config.language_identifier_backend = "transcriber"
+        source_config = SourceConfig()
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertTrue(requirements.include_voxtral)
+        self.assertTrue(requirements.include_mms_language_model)
+        self.assertTrue(requirements.include_sat)
+
+    def test_diarize_policy_adds_pyannote_and_separation(self):
+        config = Config(device="cpu")
+        source_config = SourceConfig(diarize_strategy="1,2=energy;3=pyannote;*=separate")
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertTrue(requirements.include_pyannote_diarization)
+        self.assertTrue(requirements.include_pyannote_separation)
+
+    def test_stream_mode_skips_sentence_tokenizer_prefetch(self):
+        config = Config(device="cpu", stream=True)
+        source_config = SourceConfig()
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertFalse(requirements.include_sat)
+
+    def test_isolation_requests_isolation_prefetch(self):
+        config = Config(device="cpu")
+        source_config = SourceConfig(isolate=True)
+
+        requirements = collect_install_requirements(config=config, source_config=source_config)
+
+        self.assertTrue(requirements.include_isolation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_offline_model_loading.py
+++ b/tests/test_offline_model_loading.py
@@ -1,0 +1,207 @@
+# pylint: disable=unsubscriptable-object,unpacking-non-sequence
+import os
+import sys
+import types
+import unittest
+from typing import Any, cast
+from unittest.mock import patch
+
+import verbatim.language_id as language_id_module
+import verbatim.model_cache as model_cache_module
+import verbatim.non_speech as non_speech_module
+import verbatim.transcript.sentences as sentences_module
+from verbatim.language_id import MmsLanguageIdentifier
+from verbatim.non_speech import AstNonSpeechClassifier
+from verbatim.transcript.sentences import SaTSentenceTokenizer
+
+
+class _FakeTensor:
+    def __init__(self, values):
+        self._values = values
+
+    def to(self, _device):
+        return self
+
+    def __getitem__(self, index):
+        return _FakeTensor(self._values[index])
+
+    def tolist(self):
+        return self._values
+
+
+class _FakeNoGrad:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        _ = exc_type, exc, tb
+        return False
+
+
+class _FakeFeatureExtractor:
+    last_call = None
+
+    @classmethod
+    def from_pretrained(cls, model, **kwargs):
+        cls.last_call = (model, kwargs)
+        return cls()
+
+    def __call__(self, *_args, **_kwargs):
+        return {"input_values": _FakeTensor([[0.0]])}
+
+
+class _FakeLanguageModel:
+    last_call = None
+
+    def __init__(self):
+        self.config = types.SimpleNamespace(id2label={0: "eng"})
+
+    @classmethod
+    def from_pretrained(cls, model, **kwargs):
+        cls.last_call = (model, kwargs)
+        return cls()
+
+    def to(self, _device):
+        return self
+
+    def eval(self):
+        return None
+
+
+class _FakeAudioModel:
+    last_call = None
+
+    @classmethod
+    def from_pretrained(cls, model, **kwargs):
+        cls.last_call = (model, kwargs)
+        return cls()
+
+    def to(self, _device):
+        return self
+
+    def eval(self):
+        return None
+
+    @property
+    def config(self):
+        return types.SimpleNamespace(problem_type=None)
+
+
+class _FakeSaT:
+    last_call = None
+
+    def __init__(self, *args, **kwargs):
+        _FakeSaT.last_call = (args, kwargs)
+
+    def half(self):
+        return self
+
+    def to(self, _device):
+        return self
+
+
+class TestOfflineModelLoading(unittest.TestCase):
+    def test_resolve_hf_snapshot_path_raises_clear_error_offline(self):
+        with patch.dict(os.environ, {"VERBATIM_OFFLINE": "1"}, clear=False):
+            with patch.object(model_cache_module, "_snapshot_download", side_effect=RuntimeError("missing")):
+                with self.assertRaisesRegex(RuntimeError, "Offline mode is enabled and test model 'acme/model' is not installed"):
+                    model_cache_module.resolve_hf_snapshot_path("acme/model", purpose="test model", cache_dir="D:/models")
+
+    def test_resolve_hf_file_path_raises_clear_error_offline(self):
+        with patch.dict(os.environ, {"VERBATIM_OFFLINE": "1"}, clear=False):
+            with patch.object(model_cache_module, "_hf_hub_download", side_effect=RuntimeError("missing")):
+                with self.assertRaisesRegex(RuntimeError, "Offline mode is enabled and pyannote model 'acme/model' is not installed"):
+                    model_cache_module.resolve_hf_file_path(
+                        "acme/model",
+                        filename="config.yaml",
+                        purpose="pyannote model",
+                        cache_dir="D:/models/pyannote",
+                    )
+
+    def test_mms_uses_local_files_only_when_offline(self):
+        fake_torch = types.ModuleType("torch")
+        fake_torch.no_grad = _FakeNoGrad
+        fake_torch.nn = types.SimpleNamespace(functional=types.SimpleNamespace(softmax=lambda logits, dim=-1: logits))
+        fake_transformers_auto = types.ModuleType("transformers.models.auto.feature_extraction_auto")
+        fake_transformers_auto.AutoFeatureExtractor = _FakeFeatureExtractor
+        fake_transformers_wav2vec2 = types.ModuleType("transformers.models.wav2vec2")
+        fake_transformers_wav2vec2.Wav2Vec2ForSequenceClassification = _FakeLanguageModel
+
+        with (
+            patch.dict(os.environ, {"VERBATIM_OFFLINE": "1", "HUGGINGFACE_HUB_CACHE": "D:/cache/hf"}, clear=False),
+            patch.dict(
+                sys.modules,
+                {
+                    "transformers.models.auto.feature_extraction_auto": fake_transformers_auto,
+                    "transformers.models.wav2vec2": fake_transformers_wav2vec2,
+                },
+            ),
+            patch.object(language_id_module, "torch", fake_torch),
+            patch.object(language_id_module, "resolve_hf_snapshot_path", return_value="D:/cache/mms"),
+        ):
+            MmsLanguageIdentifier(model_size_or_path="facebook/mms-lid-126", device="cpu")
+
+        self.assertIsNotNone(_FakeFeatureExtractor.last_call)
+        self.assertIsNotNone(_FakeLanguageModel.last_call)
+        feature_call = cast(tuple[Any, dict[str, Any]], _FakeFeatureExtractor.last_call)
+        model_call = cast(tuple[Any, dict[str, Any]], _FakeLanguageModel.last_call)
+        self.assertEqual(feature_call[0], "D:/cache/mms")
+        self.assertTrue(feature_call[1]["local_files_only"])
+        self.assertEqual(feature_call[1]["cache_dir"], "D:/cache/hf")
+        self.assertTrue(model_call[1]["local_files_only"])
+
+    def test_ast_uses_local_files_only_when_offline(self):
+        fake_torch = types.ModuleType("torch")
+        fake_torchaudio = types.ModuleType("torchaudio")
+        fake_transformers_auto_feature = types.ModuleType("transformers.models.auto.feature_extraction_auto")
+        fake_transformers_auto_feature.AutoFeatureExtractor = _FakeFeatureExtractor
+        fake_transformers_auto_model = types.ModuleType("transformers.models.auto.modeling_auto")
+        fake_transformers_auto_model.AutoModelForAudioClassification = _FakeAudioModel
+
+        with (
+            patch.dict(os.environ, {"VERBATIM_OFFLINE": "1", "HUGGINGFACE_HUB_CACHE": "D:/cache/hf"}, clear=False),
+            patch.dict(
+                sys.modules,
+                {
+                    "torch": fake_torch,
+                    "torchaudio": fake_torchaudio,
+                    "transformers.models.auto.feature_extraction_auto": fake_transformers_auto_feature,
+                    "transformers.models.auto.modeling_auto": fake_transformers_auto_model,
+                },
+            ),
+            patch.object(non_speech_module, "resolve_hf_snapshot_path", return_value="D:/cache/ast"),
+        ):
+            AstNonSpeechClassifier(model_name="MIT/ast-finetuned-audioset-10-10-0.4593", device="cpu")
+
+        self.assertIsNotNone(_FakeFeatureExtractor.last_call)
+        self.assertIsNotNone(_FakeAudioModel.last_call)
+        feature_call = cast(tuple[Any, dict[str, Any]], _FakeFeatureExtractor.last_call)
+        model_call = cast(tuple[Any, dict[str, Any]], _FakeAudioModel.last_call)
+        self.assertEqual(feature_call[0], "D:/cache/ast")
+        self.assertTrue(feature_call[1]["local_files_only"])
+        self.assertTrue(model_call[1]["local_files_only"])
+
+    def test_sat_uses_local_paths_and_offline_kwargs(self):
+        fake_wtpsplit = types.ModuleType("wtpsplit")
+        fake_wtpsplit.SaT = _FakeSaT
+
+        with (
+            patch.dict(os.environ, {"VERBATIM_OFFLINE": "1", "HUGGINGFACE_HUB_CACHE": "D:/cache/hf"}, clear=False),
+            patch.dict(sys.modules, {"wtpsplit": fake_wtpsplit}),
+            patch.object(
+                sentences_module,
+                "resolve_hf_snapshot_path",
+                side_effect=["D:/cache/sat-model", "D:/cache/tokenizer"],
+            ),
+        ):
+            SaTSentenceTokenizer(device="cpu")
+
+        self.assertIsNotNone(_FakeSaT.last_call)
+        args, kwargs = cast(tuple[tuple[Any, ...], dict[str, Any]], _FakeSaT.last_call)
+        self.assertEqual(args[0], "D:/cache/sat-model")
+        self.assertEqual(kwargs["tokenizer_name_or_path"], "D:/cache/tokenizer")
+        self.assertTrue(kwargs["from_pretrained_kwargs"]["local_files_only"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_offline_model_loading.py
+++ b/tests/test_offline_model_loading.py
@@ -202,6 +202,38 @@ class TestOfflineModelLoading(unittest.TestCase):
         self.assertEqual(kwargs["tokenizer_name_or_path"], "D:/cache/tokenizer")
         self.assertTrue(kwargs["from_pretrained_kwargs"]["local_files_only"])
 
+    def test_sat_does_not_double_prefix_segment_any_text_repo(self):
+        fake_wtpsplit = types.ModuleType("wtpsplit")
+        fake_wtpsplit.SaT = _FakeSaT
+
+        with (
+            patch.dict(sys.modules, {"wtpsplit": fake_wtpsplit}),
+            patch.object(
+                sentences_module,
+                "resolve_hf_snapshot_path",
+                side_effect=["D:/cache/sat-model", "D:/cache/tokenizer"],
+            ) as resolve_snapshot,
+        ):
+            SaTSentenceTokenizer(device="cpu", model="segment-any-text/sat-3l-sm")
+
+        self.assertEqual(resolve_snapshot.call_args_list[0].args[0], "segment-any-text/sat-3l-sm")
+
+    def test_sat_collapses_already_doubled_segment_any_text_repo(self):
+        fake_wtpsplit = types.ModuleType("wtpsplit")
+        fake_wtpsplit.SaT = _FakeSaT
+
+        with (
+            patch.dict(sys.modules, {"wtpsplit": fake_wtpsplit}),
+            patch.object(
+                sentences_module,
+                "resolve_hf_snapshot_path",
+                side_effect=["D:/cache/sat-model", "D:/cache/tokenizer"],
+            ) as resolve_snapshot,
+        ):
+            SaTSentenceTokenizer(device="cpu", model="segment-any-text/segment-any-text/sat-3l-sm")
+
+        self.assertEqual(resolve_snapshot.call_args_list[0].args[0], "segment-any-text/sat-3l-sm")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/transcript/test_mms_language_identifier.py
+++ b/tests/transcript/test_mms_language_identifier.py
@@ -47,7 +47,7 @@ class FakeNoGrad:
 
 class FakeFeatureExtractor:
     @classmethod
-    def from_pretrained(cls, _model_size_or_path):
+    def from_pretrained(cls, _model_size_or_path, **_kwargs):
         return cls()
 
     def __call__(self, audio, sampling_rate, return_tensors):
@@ -65,7 +65,7 @@ class FakeModel:
         self.config = types.SimpleNamespace(id2label={0: "eng", 1: "fra", 2: "deu"})
 
     @classmethod
-    def from_pretrained(cls, _model_size_or_path):
+    def from_pretrained(cls, _model_size_or_path, **_kwargs):
         return cls()
 
     def to(self, _device):

--- a/verbatim/config.py
+++ b/verbatim/config.py
@@ -229,13 +229,33 @@ class Config:
 
         return "cpu"
 
+    @staticmethod
+    def is_device_supported(device: str) -> bool:
+        # pylint: disable=import-outside-toplevel
+        import torch
+
+        if device == "cpu":
+            return True
+        if device == "cuda":
+            return bool(torch.cuda.is_available())
+        if device == "mps":
+            return bool(platform.processor() == "arm" and platform.system() == "Darwin" and torch.backends.mps.is_available())
+        return False
+
     def configure_device(self, device: str) -> "Config":
-        # Configure device
         if device == "auto":
             self.device = Config.detect_device()
+        else:
+            if device not in ("cpu", "cuda", "mps"):
+                raise RuntimeError(f"Unsupported device '{device}'. Expected one of: auto, cpu, cuda, mps.")
+            if not Config.is_device_supported(device):
+                raise RuntimeError(f"Requested device '{device}' is not available on this system.")
+            self.device = device
 
         if self.device != "cuda":
             os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # Set CUDA_VISIBLE_DEVICES to -1 to force CPU
+        elif os.environ.get("CUDA_VISIBLE_DEVICES") == "-1":
+            del os.environ["CUDA_VISIBLE_DEVICES"]
 
         if self.device == "cuda":
             STATUS_LOG.info("Using GPU (CUDA)")
@@ -296,7 +316,7 @@ class Config:
 
         - Sets environment variables that major libs honor:
           HF_HOME/HUGGINGFACE_HUB_CACHE for Hugging Face, and a project-specific
-          VERBATIM_MODEL_CACHE and VERBATIM_OFFLINE.
+          VERBATIM_MODELDIR and VERBATIM_OFFLINE.
         - Creates directories if they do not exist.
         """
         # Offline toggle
@@ -332,7 +352,7 @@ class Config:
                 return self
 
             # Root is usable; set env and create subdirs guardedly
-            os.environ["VERBATIM_MODEL_CACHE"] = model_cache_dir
+            os.environ["VERBATIM_MODELDIR"] = model_cache_dir
 
             # XDG cache root influences many libs (incl. whisper default cache path)
             try:
@@ -350,6 +370,13 @@ class Config:
                 os.environ.setdefault("HUGGINGFACE_HUB_CACHE", os.path.join(hf_home, "hub"))
             except OSError:
                 LOG.warning(f"Could not prepare Hugging Face cache under {model_cache_dir}")
+
+            try:
+                pyannote_cache = os.path.join(model_cache_dir, "pyannote")
+                os.makedirs(pyannote_cache, exist_ok=True)
+                os.environ["PYANNOTE_CACHE"] = pyannote_cache
+            except OSError:
+                LOG.warning(f"Could not prepare pyannote cache under {model_cache_dir}")
 
         return self
 

--- a/verbatim/language_id.py
+++ b/verbatim/language_id.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 
 from .config import Config
 from .languages import normalize_language
+from .model_cache import build_transformers_load_kwargs, prefetch_hf_snapshot, resolve_hf_snapshot_path
 
 LOG = logging.getLogger(__name__)
 
@@ -45,8 +46,13 @@ class MmsLanguageIdentifier:
         else:
             torch_device = "cpu"
 
-        self._feature_extractor: Any = AutoFeatureExtractor.from_pretrained(model_size_or_path)  # nosec B615
-        self._model: Any = Wav2Vec2ForSequenceClassification.from_pretrained(model_size_or_path)  # nosec B615
+        resolved_model = resolve_hf_snapshot_path(
+            model_size_or_path,
+            purpose="MMS language model",
+        )
+        load_kwargs = build_transformers_load_kwargs()
+        self._feature_extractor: Any = AutoFeatureExtractor.from_pretrained(resolved_model, **load_kwargs)  # nosec B615
+        self._model: Any = Wav2Vec2ForSequenceClassification.from_pretrained(resolved_model, **load_kwargs)  # nosec B615
         self._model.to(torch_device)
         self._model.eval()
         self._device = torch_device
@@ -98,3 +104,7 @@ def create_language_identifier(config: Config, models: _TranscriberOwnerProtocol
     if backend == "mms":
         return MmsLanguageIdentifier(model_size_or_path=config.mms_lid_model_size, device=config.device)
     raise RuntimeError(f"Unsupported language_identifier_backend: {config.language_identifier_backend}")
+
+
+def prefetch_language_identifier_models(model_size_or_path: str) -> None:
+    prefetch_hf_snapshot(model_size_or_path)

--- a/verbatim/model_cache.py
+++ b/verbatim/model_cache.py
@@ -118,7 +118,6 @@ def _hf_hub_download(
         kwargs["cache_dir"] = cache_dir
     if token:
         kwargs["token"] = token
-        kwargs["use_auth_token"] = token
     return hf_hub_download(  # nosec B615 - revision is provided explicitly by the caller
         repo_id=kwargs["repo_id"],
         filename=kwargs["filename"],
@@ -126,7 +125,6 @@ def _hf_hub_download(
         revision=kwargs["revision"],
         cache_dir=kwargs.get("cache_dir"),
         token=kwargs.get("token"),
-        use_auth_token=kwargs.get("use_auth_token"),
     )
 
 

--- a/verbatim/model_cache.py
+++ b/verbatim/model_cache.py
@@ -1,0 +1,213 @@
+import logging
+import os
+from typing import Any, Optional
+
+LOG = logging.getLogger(__name__)
+
+
+def is_offline_mode() -> bool:
+    return os.getenv("VERBATIM_OFFLINE", "0").lower() in ("1", "true", "yes", "on")
+
+
+def get_model_cache_dir() -> Optional[str]:
+    return os.getenv("VERBATIM_MODELDIR")
+
+
+def get_hf_cache_dir() -> Optional[str]:
+    return os.getenv("HUGGINGFACE_HUB_CACHE")
+
+
+def get_pyannote_cache_dir() -> Optional[str]:
+    return os.getenv("PYANNOTE_CACHE")
+
+
+def get_audio_separator_cache_dir() -> Optional[str]:
+    cache_root = get_model_cache_dir()
+    if not cache_root:
+        return None
+    return os.path.join(cache_root, "audio-separator")
+
+
+def ensure_local_path(model_name_or_path: str) -> str:
+    return os.path.expanduser(model_name_or_path)
+
+
+def is_local_model_reference(model_name_or_path: str) -> bool:  # pylint: disable=too-many-return-statements
+    candidate = ensure_local_path(model_name_or_path)
+    if os.path.isabs(candidate):
+        return True
+    if os.path.exists(candidate):
+        return True
+    if candidate.startswith((".", "~")):
+        return True
+    if ":" in candidate:
+        return True
+    if "\\" in candidate:
+        return True
+    if candidate.startswith("/"):
+        return True
+    if candidate.count("/") > 1:
+        return True
+    return False
+
+
+def build_transformers_load_kwargs(*, offline: Optional[bool] = None, cache_dir: Optional[str] = None) -> dict[str, Any]:
+    if offline is None:
+        offline = is_offline_mode()
+    kwargs: dict[str, Any] = {
+        "local_files_only": offline,
+    }
+    effective_cache_dir = cache_dir or get_hf_cache_dir()
+    if effective_cache_dir:
+        kwargs["cache_dir"] = effective_cache_dir
+    return kwargs
+
+
+def _snapshot_download(
+    repo_id: str,
+    *,
+    cache_dir: Optional[str],
+    local_files_only: bool,
+    revision: str = "main",
+    token: Optional[str] = None,
+) -> str:
+    try:
+        from huggingface_hub import snapshot_download  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("huggingface_hub is required to resolve cached model snapshots.") from exc
+
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "local_files_only": local_files_only,
+        "revision": revision,
+    }
+    if cache_dir:
+        kwargs["cache_dir"] = cache_dir
+    if token:
+        kwargs["token"] = token
+    return snapshot_download(  # nosec B615 - revision is provided explicitly by the caller
+        repo_id=kwargs["repo_id"],
+        local_files_only=kwargs["local_files_only"],
+        revision=kwargs["revision"],
+        cache_dir=kwargs.get("cache_dir"),
+        token=kwargs.get("token"),
+    )
+
+
+def _hf_hub_download(
+    repo_id: str,
+    *,
+    filename: str,
+    cache_dir: Optional[str],
+    local_files_only: bool,
+    revision: str = "main",
+    token: Optional[str] = None,
+) -> str:
+    try:
+        from huggingface_hub import hf_hub_download  # pylint: disable=import-outside-toplevel
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("huggingface_hub is required to resolve cached model files.") from exc
+
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "filename": filename,
+        "local_files_only": local_files_only,
+        "revision": revision,
+    }
+    if cache_dir:
+        kwargs["cache_dir"] = cache_dir
+    if token:
+        kwargs["token"] = token
+        kwargs["use_auth_token"] = token
+    return hf_hub_download(  # nosec B615 - revision is provided explicitly by the caller
+        repo_id=kwargs["repo_id"],
+        filename=kwargs["filename"],
+        local_files_only=kwargs["local_files_only"],
+        revision=kwargs["revision"],
+        cache_dir=kwargs.get("cache_dir"),
+        token=kwargs.get("token"),
+        use_auth_token=kwargs.get("use_auth_token"),
+    )
+
+
+def resolve_hf_snapshot_path(
+    model_name_or_path: str,
+    *,
+    purpose: str,
+    cache_dir: Optional[str] = None,
+    revision: str = "main",
+    token: Optional[str] = None,
+    offline: Optional[bool] = None,
+) -> str:
+    candidate = ensure_local_path(model_name_or_path)
+    if is_local_model_reference(candidate):
+        return candidate
+
+    effective_offline = is_offline_mode() if offline is None else offline
+    effective_cache_dir = cache_dir or get_hf_cache_dir()
+    if not effective_offline:
+        return model_name_or_path
+
+    try:
+        return _snapshot_download(
+            model_name_or_path,
+            cache_dir=effective_cache_dir,
+            local_files_only=True,
+            revision=revision,
+            token=token,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        cache_label = effective_cache_dir or "<default Hugging Face cache>"
+        raise RuntimeError(
+            f"Offline mode is enabled and {purpose} '{model_name_or_path}' is not installed under {cache_label}. "
+            "Run the same command once with --install before retrying with --offline."
+        ) from exc
+
+
+def resolve_hf_file_path(
+    repo_id: str,
+    *,
+    filename: str,
+    purpose: str,
+    cache_dir: Optional[str] = None,
+    revision: str = "main",
+    token: Optional[str] = None,
+    offline: Optional[bool] = None,
+) -> str:
+    effective_offline = is_offline_mode() if offline is None else offline
+    effective_cache_dir = cache_dir or get_hf_cache_dir()
+    local_files_only = effective_offline
+
+    try:
+        return _hf_hub_download(
+            repo_id,
+            filename=filename,
+            cache_dir=effective_cache_dir,
+            local_files_only=local_files_only,
+            revision=revision,
+            token=token,
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        if not effective_offline:
+            raise
+        cache_label = effective_cache_dir or "<default Hugging Face cache>"
+        raise RuntimeError(
+            f"Offline mode is enabled and {purpose} '{repo_id}' is not installed under {cache_label}. "
+            "Run the same command once with --install before retrying with --offline."
+        ) from exc
+
+
+def prefetch_hf_snapshot(
+    repo_id: str,
+    *,
+    cache_dir: Optional[str] = None,
+    revision: str = "main",
+    token: Optional[str] = None,
+) -> str:
+    return _snapshot_download(
+        repo_id,
+        cache_dir=cache_dir or get_hf_cache_dir(),
+        local_files_only=False,
+        revision=revision,
+        token=token,
+    )

--- a/verbatim/non_speech.py
+++ b/verbatim/non_speech.py
@@ -90,7 +90,7 @@ class AstNonSpeechClassifier:
         if sample_rate == TARGET_SR:
             return constrain_audio_range(audio.astype(np.float32, copy=False))
 
-        waveform = self._torch.from_numpy(audio.astype(np.float32, copy=False)).unsqueeze(0)
+        waveform = self._torch.as_tensor(audio.astype(np.float32, copy=False)).unsqueeze(0)  # pyright: ignore[reportPrivateImportUsage]
         resampled = self._torchaudio.functional.resample(waveform, sample_rate, TARGET_SR)
         return constrain_audio_range(resampled.squeeze(0).cpu().numpy().astype(np.float32, copy=False))
 
@@ -138,9 +138,9 @@ class AstNonSpeechClassifier:
             with self._torch.no_grad():
                 logits = self._model(**inputs).logits
             if self._problem_type == "multi_label_classification":
-                probs = self._torch.sigmoid(logits)[0].detach().cpu().numpy().astype(np.float32, copy=False)
+                probs = logits.sigmoid()[0].detach().cpu().numpy().astype(np.float32, copy=False)
             else:
-                probs = self._torch.softmax(logits, dim=-1)[0].detach().cpu().numpy().astype(np.float32, copy=False)
+                probs = logits.softmax(dim=-1)[0].detach().cpu().numpy().astype(np.float32, copy=False)
             all_probabilities.append(probs)
 
         mean_probabilities = np.mean(np.vstack(all_probabilities), axis=0)

--- a/verbatim/non_speech.py
+++ b/verbatim/non_speech.py
@@ -6,6 +6,7 @@ from typing import List, Protocol
 import numpy as np
 from numpy.typing import NDArray
 
+from verbatim.model_cache import build_transformers_load_kwargs, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim_audio.audio import constrain_audio_range
 
 LOG = logging.getLogger(__name__)
@@ -68,8 +69,19 @@ class AstNonSpeechClassifier:
         self._torchaudio = torchaudio
         self._device = device
         self._model_name = model_name
-        self._feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)  # nosec B615 - model id is operator-configured
-        self._model = AutoModelForAudioClassification.from_pretrained(model_name).to(device)  # nosec B615 - model id is operator-configured
+        resolved_model = resolve_hf_snapshot_path(
+            model_name,
+            purpose="noise model",
+        )
+        load_kwargs = build_transformers_load_kwargs()
+        self._feature_extractor = AutoFeatureExtractor.from_pretrained(  # nosec B615 - model id is operator-configured
+            resolved_model,
+            **load_kwargs,
+        )
+        self._model = AutoModelForAudioClassification.from_pretrained(  # nosec B615 - model id is operator-configured
+            resolved_model,
+            **load_kwargs,
+        ).to(device)
         self._model.eval()
         self._problem_type = getattr(self._model.config, "problem_type", None)
         LOG.info("Loaded AST non-speech classifier model=%s device=%s", model_name, device)
@@ -140,3 +152,7 @@ def create_non_speech_classifier(*, backend: str, device: str, model_name: str) 
     if normalized == "ast":
         return AstNonSpeechClassifier(model_name=model_name, device=device)
     raise RuntimeError(f"Unsupported non_speech_backend: {backend}")
+
+
+def prefetch_non_speech_models(model_name: str) -> None:
+    prefetch_hf_snapshot(model_name)

--- a/verbatim/prefetch.py
+++ b/verbatim/prefetch.py
@@ -3,16 +3,30 @@ import os
 import platform
 import re
 import sys
+from dataclasses import dataclass
 from typing import Optional
 
-# pylint: disable=broad-exception-caught
-
-# Note on import order:
-# We import huggingface_hub inside prefetch() after applying cache/offline env so that
-# the library picks up VERBATIM/HF_* cache dirs. Importing at module level would make
-# it stick to the user's default ~/.cache path.
+from verbatim.config import Config
+from verbatim_audio.sources.sourceconfig import SourceConfig
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_SENTENCE_TOKENIZER_MODEL = "sat-3l-sm"
+DEFAULT_SENTENCE_TOKENIZER_TOKENIZER = "facebookAI/xlm-roberta-base"
+
+
+@dataclass
+class InstallRequirements:
+    include_sat: bool = False
+    include_mms_language_model: bool = False
+    include_ast_noise_model: bool = False
+    include_faster_whisper: bool = False
+    include_mlx_whisper: bool = False
+    include_qwen_asr: bool = False
+    include_voxtral: bool = False
+    include_pyannote_diarization: bool = False
+    include_pyannote_separation: bool = False
+    include_isolation: bool = False
 
 
 def _bool_env(name: str, default: bool = False) -> bool:
@@ -23,27 +37,22 @@ def _bool_env(name: str, default: bool = False) -> bool:
 
 
 def apply_cache_env(model_cache_dir: Optional[str], offline: bool = False) -> None:
-    """Apply cache/offline environment variables for this process.
-
-    Mirrors Config.configure_cache without importing the full Config to avoid side effects.
-    """
+    """Apply cache/offline environment variables for this process."""
     if offline:
         os.environ["VERBATIM_OFFLINE"] = "1"
         os.environ["HF_HUB_OFFLINE"] = "1"
         os.environ["TRANSFORMERS_OFFLINE"] = "1"
     else:
-        # Prefetch requires network; make sure offline flags do not linger
         os.environ["VERBATIM_OFFLINE"] = "0"
         os.environ["HF_HUB_OFFLINE"] = "0"
         os.environ["TRANSFORMERS_OFFLINE"] = "0"
 
-    # Default to local project cache if unspecified
     if not model_cache_dir:
         model_cache_dir = os.path.join(os.getcwd(), ".verbatim")
 
     if model_cache_dir:
         os.makedirs(model_cache_dir, exist_ok=True)
-        os.environ["VERBATIM_MODEL_CACHE"] = model_cache_dir
+        os.environ["VERBATIM_MODELDIR"] = model_cache_dir
 
         xdg_cache = os.path.join(model_cache_dir, "xdg")
         os.makedirs(xdg_cache, exist_ok=True)
@@ -53,29 +62,28 @@ def apply_cache_env(model_cache_dir: Optional[str], offline: bool = False) -> No
         os.makedirs(hf_home, exist_ok=True)
         os.environ.setdefault("HF_HOME", hf_home)
         os.environ.setdefault("HUGGINGFACE_HUB_CACHE", os.path.join(hf_home, "hub"))
+
+        pyannote_cache = os.path.join(model_cache_dir, "pyannote")
+        os.makedirs(pyannote_cache, exist_ok=True)
+        os.environ["PYANNOTE_CACHE"] = pyannote_cache
     LOG.debug(
-        "Cache env: VERBATIM_MODEL_CACHE=%s HF_HOME=%s HUGGINGFACE_HUB_CACHE=%s",
-        os.getenv("VERBATIM_MODEL_CACHE"),
+        "Cache env: VERBATIM_MODELDIR=%s HF_HOME=%s HUGGINGFACE_HUB_CACHE=%s PYANNOTE_CACHE=%s",
+        os.getenv("VERBATIM_MODELDIR"),
         os.getenv("HF_HOME"),
         os.getenv("HUGGINGFACE_HUB_CACHE"),
+        os.getenv("PYANNOTE_CACHE"),
     )
 
 
 def _hf_models_dir(repo_id: str) -> str:
-    """Return the Hugging Face hub models directory name for a repo id.
-
-    Example: "org/name" -> "models--org--name"
-    """
     parts = repo_id.split("/")
     if len(parts) != 2:
-        # Best-effort; fallback to replacing separators
         safe = repo_id.replace("/", "--")
         return f"models--{safe}"
     return f"models--{parts[0]}--{parts[1]}"
 
 
 def _classify_whisper_model(value: str) -> str:
-    """Classify whisper model as size token, HF repo id, or local path."""
     model_kind = "size"
     if not value:
         model_kind = "unknown"
@@ -97,25 +105,13 @@ def _classify_whisper_model(value: str) -> str:
 
 
 def _resolve_hf_revision(repo_id: str, *, local_dir: Optional[str] = None) -> str:
-    """Best-effort resolution of a pinned revision for a HF repo.
-
-    Tries to read a cached commit hash from refs/main if available in either:
-      - the provided local_dir (when using snapshot_download local_dir), or
-      - the global HF cache pointed by HUGGINGFACE_HUB_CACHE/HF_HOME.
-
-    Falls back to 'main' when no hash is found. Bandit B615 accepts the presence
-    of the 'revision' argument; when available we prefer an actual SHA.
-    """
-    # Regex for 40-hex commit SHA
     sha_re = re.compile(r"^[0-9a-f]{40}$")
-
     candidates = []
     models_dirname = _hf_models_dir(repo_id)
 
     if local_dir:
         candidates.append(os.path.join(local_dir, models_dirname, "refs", "main"))
 
-    # Global hub cache (preferred path when not using local_dir)
     hub_cache = os.getenv("HUGGINGFACE_HUB_CACHE")
     if not hub_cache:
         hf_home = os.getenv("HF_HOME")
@@ -126,8 +122,8 @@ def _resolve_hf_revision(repo_id: str, *, local_dir: Optional[str] = None) -> st
 
     for ref_path in candidates:
         try:
-            with open(ref_path, "r", encoding="utf-8") as f:
-                ref = f.read().strip()
+            with open(ref_path, "r", encoding="utf-8") as handle:
+                ref = handle.read().strip()
             if sha_re.match(ref):
                 return ref
         except OSError:
@@ -136,77 +132,81 @@ def _resolve_hf_revision(repo_id: str, *, local_dir: Optional[str] = None) -> st
     return "main"
 
 
-def prefetch(
-    *,
-    model_cache_dir: Optional[str],
-    whisper_size: str = "large-v3",
-    include_pyannote: bool = True,
-    include_faster_whisper: bool = True,
-    # Defer platform checks to runtime to keep import safe on Windows
-    include_mlx_whisper: Optional[bool] = None,
-) -> None:
-    """Prefetch commonly used models into the cache.
+def _parse_diarization_requirements(source_config: SourceConfig) -> tuple[bool, bool]:
+    strategy = source_config.diarize_strategy
+    if not strategy:
+        return False, False
 
-    This function attempts to only download/copy into the provided cache directory,
-    so later runs can use --offline.
-    """
-    # Compute default for MLX Whisper lazily to avoid os.uname() at import time
-    if include_mlx_whisper is None:
-        include_mlx_whisper = sys.platform == "darwin" and platform.machine().lower() in ("arm64", "aarch64")
+    if strategy in ("pyannote", "separate"):
+        return strategy == "pyannote", strategy == "separate"
+
+    if "=" not in strategy and ";" not in strategy:
+        return False, False
+
+    try:
+        from verbatim_diarization.policy import parse_policy  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        return False, False
+
+    include_pyannote = False
+    include_separate = False
+    for clause in parse_policy(strategy):
+        include_pyannote = include_pyannote or clause.strategy == "pyannote"
+        include_separate = include_separate or clause.strategy == "separate"
+    return include_pyannote, include_separate
+
+
+def collect_install_requirements(*, config: Config, source_config: SourceConfig) -> InstallRequirements:
+    requirements = InstallRequirements()
+    asr_backend = (config.transcriber_backend or "auto").lower()
+
+    if not config.stream:
+        requirements.include_sat = True
+
+    if asr_backend in ("qwen", "qwen-asr"):
+        requirements.include_qwen_asr = True
+    elif asr_backend == "voxtral":
+        requirements.include_voxtral = True
+    else:
+        requirements.include_faster_whisper = True
+        requirements.include_mlx_whisper = sys.platform == "darwin" and platform.machine().lower() in ("arm64", "aarch64")
+
+    language_backend = (config.language_identifier_backend or "transcriber").lower()
+    if language_backend == "mms" or asr_backend == "voxtral":
+        requirements.include_mms_language_model = True
+
+    if (config.non_speech_backend or "energy").lower() == "ast":
+        requirements.include_ast_noise_model = True
+
+    include_pyannote, include_separate = _parse_diarization_requirements(source_config)
+    requirements.include_pyannote_diarization = include_pyannote or include_separate
+    requirements.include_pyannote_separation = include_separate
+    requirements.include_isolation = source_config.isolate is not None
+    return requirements
+
+
+def prefetch_faster_whisper_model(*, whisper_size: str, include_mlx_whisper: bool) -> None:
+    try:  # type: ignore
+        from huggingface_hub import snapshot_download  # pylint: disable=import-outside-toplevel
+        from huggingface_hub.errors import HfHubHTTPError  # pylint: disable=import-outside-toplevel
+        from huggingface_hub.utils import LocalEntryNotFoundError  # pylint: disable=import-outside-toplevel
+    except ImportError:  # pragma: no cover
+        LOG.warning("huggingface_hub not available: cannot prefetch HF-hosted models")
+        return
 
     model_kind = _classify_whisper_model(whisper_size)
     if model_kind == "path":
-        LOG.info(
-            "Skipping whisper model prefetch for local/custom path: %s",
-            whisper_size,
-        )
-        include_mlx_whisper = False
-        include_faster_whisper = False
-    elif model_kind == "hf_repo":
-        LOG.info(
-            "Prefetching custom HF whisper repo: %s",
-            whisper_size,
-        )
-        include_mlx_whisper = False
-
-    apply_cache_env(model_cache_dir, offline=False)
-
-    # Lazy-import huggingface_hub after env is configured so it uses our cache dirs
-    # pylint: disable=import-outside-toplevel
-    try:  # type: ignore
-        from huggingface_hub import snapshot_download  # type: ignore
-        from huggingface_hub.errors import HfHubHTTPError  # type: ignore
-        from huggingface_hub.utils import LocalEntryNotFoundError  # type: ignore
-    except ImportError:  # pragma: no cover
-        snapshot_download = None  # type: ignore
-        HfHubHTTPError = Exception  # type: ignore
-        LocalEntryNotFoundError = Exception  # type: ignore
-
-    # 1) Hugging Face models via huggingface_hub
-    if snapshot_download is None:  # pragma: no cover - optional path
-        LOG.warning("huggingface_hub not available: cannot prefetch HF-hosted models")
+        LOG.info("Skipping whisper model prefetch for local/custom path: %s", whisper_size)
+        return
 
     hf_token = os.getenv("HUGGINGFACE_TOKEN")
     hub_cache = os.getenv("HUGGINGFACE_HUB_CACHE")
 
-    # Pyannote diarization/separation
-    if include_pyannote:
-        try:
-            from verbatim_diarization.prefetch import prefetch_diarization_models
-        except ImportError as exc:  # pragma: no cover - defensive
-            LOG.warning("verbatim_diarization not available; skipping diarization prefetch: %s", exc)
-        else:
-            try:
-                prefetch_diarization_models(hf_token=hf_token, cache_dir=hub_cache, offline=False)
-            except ImportError as exc:  # pragma: no cover - optional dependency missing
-                LOG.warning("pyannote not available; skipping diarization prefetch: %s", exc)
-
-    # MLX Whisper models (macOS/Apple Silicon) hosted on HF
-    if include_mlx_whisper and snapshot_download is not None:
+    if include_mlx_whisper:
         mlx_repo = f"mlx-community/whisper-{whisper_size}-mlx"
         mlx_rev = _resolve_hf_revision(mlx_repo)
         try:
-            LOG.info(f"Prefetching HF repo: {mlx_repo} (rev={mlx_rev})")
+            LOG.info("Prefetching HF repo: %s (rev=%s)", mlx_repo, mlx_rev)
             local_path = snapshot_download(  # nosec B615 - revision provided via variable
                 repo_id=mlx_repo,
                 token=hf_token,
@@ -215,56 +215,106 @@ def prefetch(
                 cache_dir=hub_cache,
             )
             LOG.info("Downloaded: %s (rev=%s) to %s", mlx_repo, mlx_rev, local_path)
-        except HfHubHTTPError as e:  # pragma: no cover
-            LOG.warning(f"Failed to prefetch {mlx_repo}: {e}")
+        except HfHubHTTPError as exc:  # pragma: no cover
+            LOG.warning("Failed to prefetch %s: %s", mlx_repo, exc)
 
-    # 2) Faster-Whisper: populate cache without heavy initialization
-    if include_faster_whisper:
+    try:
+        cache_root = os.getenv("VERBATIM_MODELDIR")
+        download_root = os.path.join(cache_root, "faster-whisper") if cache_root else None
+        fw_repo = f"Systran/faster-whisper-{whisper_size}" if model_kind != "hf_repo" else whisper_size
+        fw_rev = _resolve_hf_revision(fw_repo, local_dir=download_root)
+
+        if download_root:
+            os.makedirs(download_root, exist_ok=True)
+            try:
+                snapshot_download(  # nosec B615 - revision provided via variable
+                    repo_id=fw_repo,
+                    local_files_only=True,
+                    revision=fw_rev,
+                    cache_dir=download_root,
+                )
+                LOG.info("Already cached: faster-whisper (%s)", whisper_size)
+            except LocalEntryNotFoundError:
+                LOG.info("Prefetching faster-whisper model: %s", whisper_size)
+                local_path = snapshot_download(  # nosec B615 - revision provided via variable
+                    repo_id=fw_repo,
+                    local_files_only=False,
+                    revision=fw_rev,
+                    cache_dir=download_root,
+                )
+                LOG.info("Downloaded: %s (rev=%s) to %s", fw_repo, fw_rev, local_path)
+        else:
+            LOG.info("Prefetching faster-whisper model: %s", whisper_size)
+            local_path = snapshot_download(  # nosec B615 - revision provided via variable
+                repo_id=fw_repo,
+                local_files_only=False,
+                revision=fw_rev,
+                cache_dir=hub_cache,
+            )
+            LOG.info("Downloaded (HF cache): %s (rev=%s) to %s", fw_repo, fw_rev, local_path)
+    except (OSError, HfHubHTTPError) as exc:  # pragma: no cover
+        LOG.warning("Failed to prefetch faster-whisper %s: %s", whisper_size, exc)
+
+
+def prefetch(*, config: Config, source_config: SourceConfig) -> None:
+    """Prefetch the models required by the effective runtime configuration."""
+    apply_cache_env(config.model_cache_dir, offline=False)
+    requirements = collect_install_requirements(config=config, source_config=source_config)
+
+    if requirements.include_sat:
+        from verbatim.transcript.sentences import prefetch_sentence_tokenizer_models  # pylint: disable=import-outside-toplevel
+
+        prefetch_sentence_tokenizer_models(
+            model_name_or_path=DEFAULT_SENTENCE_TOKENIZER_MODEL,
+            tokenizer_name_or_path=DEFAULT_SENTENCE_TOKENIZER_TOKENIZER,
+        )
+
+    if requirements.include_mms_language_model:
+        from verbatim.language_id import prefetch_language_identifier_models  # pylint: disable=import-outside-toplevel
+
+        prefetch_language_identifier_models(config.mms_lid_model_size)
+
+    if requirements.include_ast_noise_model:
+        from verbatim.non_speech import prefetch_non_speech_models  # pylint: disable=import-outside-toplevel
+
+        prefetch_non_speech_models(config.ast_audio_model_size)
+
+    if requirements.include_qwen_asr:
+        from verbatim.voices.transcribe.qwen_asr import prefetch_qwen_models  # pylint: disable=import-outside-toplevel
+
+        prefetch_qwen_models(
+            model_size_or_path=config.qwen_asr_model_size,
+            aligner_model_size_or_path=config.qwen_aligner_model_size,
+        )
+
+    if requirements.include_voxtral:
+        from verbatim.voices.transcribe.voxtral import prefetch_voxtral_models  # pylint: disable=import-outside-toplevel
+
+        prefetch_voxtral_models(
+            model_size_or_path=config.voxtral_model_size,
+            aligner_model_size_or_path=config.qwen_aligner_model_size,
+        )
+
+    if requirements.include_faster_whisper:
+        prefetch_faster_whisper_model(
+            whisper_size=config.whisper_model_size,
+            include_mlx_whisper=requirements.include_mlx_whisper,
+        )
+
+    if requirements.include_pyannote_diarization or requirements.include_pyannote_separation:
         try:
-            cache_root = os.getenv("VERBATIM_MODEL_CACHE")
-            download_root = os.path.join(cache_root, "faster-whisper") if cache_root else None
-            fw_repo = f"Systran/faster-whisper-{whisper_size}" if model_kind != "hf_repo" else whisper_size
-            fw_rev = _resolve_hf_revision(fw_repo, local_dir=download_root)
+            from verbatim_diarization.prefetch import prefetch_diarization_models  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:  # pragma: no cover - defensive
+            LOG.warning("verbatim_diarization not available; skipping diarization prefetch: %s", exc)
+        else:
+            prefetch_diarization_models(
+                hf_token=os.getenv("HUGGINGFACE_TOKEN"),
+                cache_dir=os.getenv("PYANNOTE_CACHE"),
+                offline=False,
+                include_separation=requirements.include_pyannote_separation,
+            )
 
-            if download_root:
-                os.makedirs(download_root, exist_ok=True)
-                if snapshot_download is not None:
-                    try:
-                        # Check if already present in the same cache layout runtime will use
-                        snapshot_download(  # nosec B615 - revision provided via variable
-                            repo_id=fw_repo,
-                            local_files_only=True,
-                            revision=fw_rev,
-                            cache_dir=download_root,
-                        )
-                        LOG.info("Already cached: faster-whisper (%s)", whisper_size)
-                    except LocalEntryNotFoundError:
-                        LOG.info(f"Prefetching faster-whisper model: {whisper_size}")
-                        # Populate download_root as a full HF cache so runtime offline lookup succeeds
-                        local_path = snapshot_download(  # nosec B615 - revision provided via variable
-                            repo_id=fw_repo,
-                            local_files_only=False,
-                            revision=fw_rev,
-                            cache_dir=download_root,
-                        )
-                        LOG.info("Downloaded: %s (rev=%s) to %s", fw_repo, fw_rev, local_path)
-            else:
-                if snapshot_download is not None:
-                    LOG.info(f"Prefetching faster-whisper model: {whisper_size}")
-                    # No specific download_root: populate global project HF cache
-                    local_path = snapshot_download(  # nosec B615 - revision provided via variable
-                        repo_id=fw_repo,
-                        local_files_only=False,
-                        revision=fw_rev,
-                        cache_dir=hub_cache,
-                    )
-                    LOG.info("Downloaded (HF cache): %s (rev=%s) to %s", fw_repo, fw_rev, local_path)
-        except (OSError, HfHubHTTPError) as e:  # pragma: no cover
-            LOG.warning(f"Failed to prefetch faster-whisper {whisper_size}: {e}")
+    if requirements.include_isolation:
+        from verbatim.voices.isolation import prefetch_isolation_model  # pylint: disable=import-outside-toplevel
 
-    # 3) Voice isolation: provide guidance; download may be manual depending on backend
-    cache_root = os.getenv("VERBATIM_MODEL_CACHE")
-    if cache_root:
-        iso_dir = os.path.join(cache_root, "audio-separator")
-        os.makedirs(iso_dir, exist_ok=True)
-        LOG.info(f"If needed, place MDX checkpoint (e.g., MDX23C-8KFFT-InstVoc_HQ_2.ckpt) under: {iso_dir} to enable offline isolation")
+        prefetch_isolation_model()

--- a/verbatim/prefetch.py
+++ b/verbatim/prefetch.py
@@ -56,12 +56,12 @@ def apply_cache_env(model_cache_dir: Optional[str], offline: bool = False) -> No
 
         xdg_cache = os.path.join(model_cache_dir, "xdg")
         os.makedirs(xdg_cache, exist_ok=True)
-        os.environ.setdefault("XDG_CACHE_HOME", xdg_cache)
+        os.environ["XDG_CACHE_HOME"] = xdg_cache
 
         hf_home = os.path.join(model_cache_dir, "hf")
         os.makedirs(hf_home, exist_ok=True)
-        os.environ.setdefault("HF_HOME", hf_home)
-        os.environ.setdefault("HUGGINGFACE_HUB_CACHE", os.path.join(hf_home, "hub"))
+        os.environ["HF_HOME"] = hf_home
+        os.environ["HUGGINGFACE_HUB_CACHE"] = os.path.join(hf_home, "hub")
 
         pyannote_cache = os.path.join(model_cache_dir, "pyannote")
         os.makedirs(pyannote_cache, exist_ok=True)

--- a/verbatim/prefetch.py
+++ b/verbatim/prefetch.py
@@ -188,10 +188,7 @@ def collect_install_requirements(*, config: Config, source_config: SourceConfig)
 def prefetch_faster_whisper_model(*, whisper_size: str, include_mlx_whisper: bool) -> None:
     try:  # type: ignore
         from huggingface_hub import snapshot_download  # pylint: disable=import-outside-toplevel
-        from huggingface_hub.errors import (
-            HfHubHTTPError,  # pylint: disable=import-outside-toplevel
-            LocalEntryNotFoundError,  # pylint: disable=import-outside-toplevel
-        )
+        from huggingface_hub.errors import HfHubHTTPError, LocalEntryNotFoundError  # pylint: disable=import-outside-toplevel
     except ImportError:  # pragma: no cover
         LOG.warning("huggingface_hub not available: cannot prefetch HF-hosted models")
         return

--- a/verbatim/prefetch.py
+++ b/verbatim/prefetch.py
@@ -188,8 +188,10 @@ def collect_install_requirements(*, config: Config, source_config: SourceConfig)
 def prefetch_faster_whisper_model(*, whisper_size: str, include_mlx_whisper: bool) -> None:
     try:  # type: ignore
         from huggingface_hub import snapshot_download  # pylint: disable=import-outside-toplevel
-        from huggingface_hub.errors import HfHubHTTPError  # pylint: disable=import-outside-toplevel
-        from huggingface_hub.utils import LocalEntryNotFoundError  # pylint: disable=import-outside-toplevel
+        from huggingface_hub.errors import (
+            HfHubHTTPError,  # pylint: disable=import-outside-toplevel
+            LocalEntryNotFoundError,  # pylint: disable=import-outside-toplevel
+        )
     except ImportError:  # pragma: no cover
         LOG.warning("huggingface_hub not available: cannot prefetch HF-hosted models")
         return

--- a/verbatim/transcript/sentences.py
+++ b/verbatim/transcript/sentences.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from time import perf_counter
 from typing import List
 
+from verbatim.model_cache import build_transformers_load_kwargs, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim.transcript.words import Word
 from verbatim_audio.audio import samples_to_seconds
 
@@ -53,12 +54,24 @@ class FastSentenceTokenizer(SentenceTokenizer):
 
 
 class SaTSentenceTokenizer(SentenceTokenizer):
-    def __init__(self, device: str, model="sat-3l-sm"):
+    def __init__(self, device: str, model="sat-3l-sm", tokenizer_name_or_path: str = "facebookAI/xlm-roberta-base"):
         LOG.debug("Lazy-loading SaT Sentence Tokenizer (model=%s)", model)
         start = perf_counter()
         from wtpsplit import SaT  # pylint: disable=import-outside-toplevel
 
-        self.sat_sm = SaT(model)
+        resolved_model = resolve_hf_snapshot_path(
+            f"segment-any-text/{model}" if "/" not in model and not re.search(r"[\\/]", model) else model,
+            purpose="sentence tokenizer model",
+        )
+        resolved_tokenizer = resolve_hf_snapshot_path(
+            tokenizer_name_or_path,
+            purpose="sentence tokenizer tokenizer",
+        )
+        self.sat_sm = SaT(
+            resolved_model,
+            tokenizer_name_or_path=resolved_tokenizer,
+            from_pretrained_kwargs=build_transformers_load_kwargs(),
+        )
         self.sat_sm.half().to(device)
         LOG.debug("SaT Sentence Tokenizer ready in %.2fs", perf_counter() - start)
 
@@ -174,3 +187,11 @@ class BoundedSentenceTokenizer(SentenceTokenizer):
             return tok
 
         return self.bounding_tokenizer.split(words=words)
+
+
+def prefetch_sentence_tokenizer_models(*, model_name_or_path: str = "sat-3l-sm", tokenizer_name_or_path: str = "facebookAI/xlm-roberta-base") -> None:
+    repo_id = model_name_or_path
+    if "/" not in repo_id and not re.search(r"[\\/]", repo_id):
+        repo_id = f"segment-any-text/{repo_id}"
+    prefetch_hf_snapshot(repo_id)
+    prefetch_hf_snapshot(tokenizer_name_or_path)

--- a/verbatim/transcript/sentences.py
+++ b/verbatim/transcript/sentences.py
@@ -60,17 +60,19 @@ class SaTSentenceTokenizer(SentenceTokenizer):
         from wtpsplit import SaT  # pylint: disable=import-outside-toplevel
 
         resolved_model = resolve_hf_snapshot_path(
-            f"segment-any-text/{model}" if "/" not in model and not re.search(r"[\\/]", model) else model,
+            _normalize_sat_model_name(model),
             purpose="sentence tokenizer model",
         )
         resolved_tokenizer = resolve_hf_snapshot_path(
             tokenizer_name_or_path,
             purpose="sentence tokenizer tokenizer",
         )
+        sat_model_name_or_path = _normalize_sat_model_name(resolved_model)
         self.sat_sm = SaT(
-            resolved_model,
+            sat_model_name_or_path,
             tokenizer_name_or_path=resolved_tokenizer,
             from_pretrained_kwargs=build_transformers_load_kwargs(),
+            hub_prefix=None,
         )
         self.sat_sm.half().to(device)
         LOG.debug("SaT Sentence Tokenizer ready in %.2fs", perf_counter() - start)
@@ -190,8 +192,20 @@ class BoundedSentenceTokenizer(SentenceTokenizer):
 
 
 def prefetch_sentence_tokenizer_models(*, model_name_or_path: str = "sat-3l-sm", tokenizer_name_or_path: str = "facebookAI/xlm-roberta-base") -> None:
-    repo_id = model_name_or_path
-    if "/" not in repo_id and not re.search(r"[\\/]", repo_id):
-        repo_id = f"segment-any-text/{repo_id}"
+    repo_id = _normalize_sat_model_name(model_name_or_path)
     prefetch_hf_snapshot(repo_id)
     prefetch_hf_snapshot(tokenizer_name_or_path)
+
+
+def _normalize_sat_model_name(model_name_or_path: str) -> str:
+    candidate = model_name_or_path.strip()
+    while candidate.startswith("segment-any-text/segment-any-text/"):
+        candidate = candidate[len("segment-any-text/") :]
+    if candidate.startswith("segment-any-text/"):
+        suffix = candidate[len("segment-any-text/") :]
+        if "/" in suffix and not re.search(r"[\\/]", suffix):
+            return suffix
+        return candidate
+    if "/" not in candidate and not re.search(r"[\\/]", candidate):
+        return f"segment-any-text/{candidate}"
+    return candidate

--- a/verbatim/transcript/sentences.py
+++ b/verbatim/transcript/sentences.py
@@ -3,7 +3,7 @@ import math
 import re
 from abc import ABC, abstractmethod
 from time import perf_counter
-from typing import List
+from typing import List, cast
 
 from verbatim.model_cache import build_transformers_load_kwargs, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim.transcript.words import Word
@@ -72,7 +72,7 @@ class SaTSentenceTokenizer(SentenceTokenizer):
             sat_model_name_or_path,
             tokenizer_name_or_path=resolved_tokenizer,
             from_pretrained_kwargs=build_transformers_load_kwargs(),
-            hub_prefix=None,
+            hub_prefix=cast(str, None),
         )
         self.sat_sm.half().to(device)
         LOG.debug("SaT Sentence Tokenizer ready in %.2fs", perf_counter() - start)

--- a/verbatim/voices/isolation.py
+++ b/verbatim/voices/isolation.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import tempfile
 from typing import Optional, Tuple
 
 import librosa
@@ -8,6 +9,7 @@ from audio_separator.separator import Separator
 from numpy.typing import NDArray
 from scipy.io.wavfile import write as wav_write
 
+from verbatim.model_cache import get_audio_separator_cache_dir, is_offline_mode
 from verbatim_audio.audio import format_audio
 
 # Configure logger
@@ -16,9 +18,11 @@ LOG = logging.getLogger(__name__)
 
 class VoiceIsolation:
     def __init__(self, log_level: int = logging.WARN, model_name: str = "MDX23C-8KFFT-InstVoc_HQ_2.ckpt"):
-        self.separator = Separator(log_level=log_level, sample_rate=16000)
-        cache_root = os.getenv("VERBATIM_MODEL_CACHE")
-        offline_env = os.getenv("VERBATIM_OFFLINE", "0").lower() in ("1", "true", "yes")
+        cache_dir = get_audio_separator_cache_dir()
+        fallback_cache_dir = os.path.join(tempfile.gettempdir(), "audio-separator-models")
+        self.separator = Separator(log_level=log_level, sample_rate=16000, model_file_dir=cache_dir or fallback_cache_dir)
+        cache_root = os.getenv("VERBATIM_MODELDIR")
+        offline_env = is_offline_mode()
 
         # If a cache is configured, prefer a cached checkpoint path under it
         model_path = model_name
@@ -90,3 +94,13 @@ class VoiceIsolation:
             formatted_voice_audio = formatted_voice_audio[:input_length]
 
         return formatted_voice_audio
+
+
+def prefetch_isolation_model(model_name: str = "MDX23C-8KFFT-InstVoc_HQ_2.ckpt") -> None:
+    cache_dir = get_audio_separator_cache_dir()
+    if not cache_dir:
+        LOG.warning("No VERBATIM_MODELDIR configured; skipping isolation model prefetch.")
+        return
+    os.makedirs(cache_dir, exist_ok=True)
+    separator = Separator(log_level=logging.WARN, sample_rate=16000, model_file_dir=cache_dir)
+    separator.download_model_files(model_name)

--- a/verbatim/voices/silences.py
+++ b/verbatim/voices/silences.py
@@ -36,7 +36,7 @@ class SileroVoiceActivityDetection(VoiceActivityDetection):
         min_speech_duration_ms: int = 250,
         min_silence_duration_ms: int = 100,
     ) -> List[Dict[str, int]]:
-        audio_tensor = torch.from_numpy(audio).float()
+        audio_tensor = torch.as_tensor(audio).float()  # pyright: ignore[reportPrivateImportUsage]
         speech_timestamps = get_speech_timestamps(
             audio=audio_tensor,
             model=self.model,

--- a/verbatim/voices/transcribe/faster_whisper.py
+++ b/verbatim/voices/transcribe/faster_whisper.py
@@ -29,7 +29,7 @@ class FasterWhisperTranscriber(Transcriber):
             whisper_temperatures = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
 
         # Configure cache root and offline mode from environment
-        cache_root = os.getenv("VERBATIM_MODEL_CACHE")
+        cache_root = os.getenv("VERBATIM_MODELDIR")
         download_root = os.path.join(cache_root, "faster-whisper") if cache_root else None
         offline_env = os.getenv("VERBATIM_OFFLINE", "0").lower() in ("1", "true", "yes")
 

--- a/verbatim/voices/transcribe/qwen_asr.py
+++ b/verbatim/voices/transcribe/qwen_asr.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from contextlib import contextmanager
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple
@@ -6,6 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from numpy.typing import NDArray
 
 from verbatim.languages import normalize_language
+from verbatim.model_cache import get_hf_cache_dir, is_offline_mode, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim_audio.audio import samples_to_seconds
 
 from ...transcript.words import Word
@@ -80,16 +82,34 @@ class QwenAsrTranscriber(Transcriber):
         else:
             device_map = "cpu"
 
+        offline_env = is_offline_mode()
+        hf_cache_dir = get_hf_cache_dir()
+        resolved_model = resolve_hf_snapshot_path(
+            model_size_or_path,
+            purpose="Qwen ASR model",
+            cache_dir=hf_cache_dir,
+            offline=offline_env,
+        )
+        resolved_aligner = resolve_hf_snapshot_path(
+            aligner_model_size_or_path,
+            purpose="Qwen forced aligner",
+            cache_dir=hf_cache_dir,
+            offline=offline_env,
+        )
         with self._suppress_transformers_generation_warnings():
             self._model = Qwen3ASRModel.from_pretrained(
-                model_size_or_path,
+                resolved_model,
                 dtype=qwen_dtype,
                 device_map=device_map,
-                forced_aligner=aligner_model_size_or_path,
+                forced_aligner=resolved_aligner,
                 forced_aligner_kwargs={
                     "dtype": qwen_dtype,
                     "device_map": device_map,
+                    "local_files_only": offline_env,
+                    "cache_dir": hf_cache_dir,
                 },
+                local_files_only=offline_env,
+                cache_dir=hf_cache_dir,
                 max_inference_batch_size=max_inference_batch_size,
                 max_new_tokens=max_new_tokens,
             )
@@ -404,3 +424,10 @@ class QwenAsrTranscriber(Transcriber):
         )
 
         return transcript_words
+
+
+def prefetch_qwen_models(*, model_size_or_path: str, aligner_model_size_or_path: str) -> None:
+    if not os.path.exists(os.path.expanduser(model_size_or_path)):
+        prefetch_hf_snapshot(model_size_or_path)
+    if not os.path.exists(os.path.expanduser(aligner_model_size_or_path)):
+        prefetch_hf_snapshot(aligner_model_size_or_path)

--- a/verbatim/voices/transcribe/voxtral.py
+++ b/verbatim/voices/transcribe/voxtral.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Tuple, cast
 
 from numpy.typing import NDArray
 
+from verbatim.model_cache import get_hf_cache_dir, is_offline_mode, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim_audio.audio import samples_to_seconds
 
 from ...transcript.words import Word
@@ -46,22 +47,41 @@ class VoxtralTranscriber(Transcriber):
         else:
             device_map = "cpu"
 
-        offline_env = os.getenv("VERBATIM_OFFLINE", "0").lower() in ("1", "true", "yes")
+        offline_env = is_offline_mode()
+        hf_cache_dir = get_hf_cache_dir()
+        resolved_model = resolve_hf_snapshot_path(
+            model_size_or_path,
+            purpose="Voxtral ASR model",
+            cache_dir=hf_cache_dir,
+            offline=offline_env,
+        )
+        resolved_aligner = resolve_hf_snapshot_path(
+            aligner_model_size_or_path,
+            purpose="Qwen forced aligner",
+            cache_dir=hf_cache_dir,
+            offline=offline_env,
+        )
 
         self._model_size_or_path = model_size_or_path
-        self._processor: Any = VoxtralProcessor.from_pretrained(model_size_or_path, local_files_only=offline_env)  # nosec B615
+        self._processor: Any = VoxtralProcessor.from_pretrained(  # nosec B615
+            resolved_model,
+            local_files_only=offline_env,
+            cache_dir=hf_cache_dir,
+        )
         self._model: Any = VoxtralForConditionalGeneration.from_pretrained(  # nosec B615
-            model_size_or_path,
+            resolved_model,
             dtype=voxtral_dtype,
             device_map=device_map,
             low_cpu_mem_usage=True,
             local_files_only=offline_env,
+            cache_dir=hf_cache_dir,
         )
         self._aligner: Any = Qwen3ForcedAligner.from_pretrained(
-            aligner_model_size_or_path,
+            resolved_aligner,
             dtype=voxtral_dtype,
             device_map=device_map,
             local_files_only=offline_env,
+            cache_dir=hf_cache_dir,
         )
         self._device_map = device_map
         self._max_new_tokens = max_new_tokens
@@ -100,7 +120,7 @@ class VoxtralTranscriber(Transcriber):
             return lang[0], 1.0
         if not self._warned_guess_language:
             LOG.warning(
-                "Voxtral backend does not provide native language identification. Use language_identifier_backend='mms' for reliable code-switching."
+                "Voxtral backend does not provide native language identification. Use language_backend='mms' for reliable code-switching."
             )
             self._warned_guess_language = True
         return lang[0], 0.0
@@ -206,3 +226,10 @@ class VoxtralTranscriber(Transcriber):
             lang,
         )
         return transcript_words
+
+
+def prefetch_voxtral_models(*, model_size_or_path: str, aligner_model_size_or_path: str) -> None:
+    if not os.path.exists(os.path.expanduser(model_size_or_path)):
+        prefetch_hf_snapshot(model_size_or_path)
+    if not os.path.exists(os.path.expanduser(aligner_model_size_or_path)):
+        prefetch_hf_snapshot(aligner_model_size_or_path)

--- a/verbatim/voices/transcribe/voxtral.py
+++ b/verbatim/voices/transcribe/voxtral.py
@@ -119,9 +119,7 @@ class VoxtralTranscriber(Transcriber):
         if len(lang) == 1:
             return lang[0], 1.0
         if not self._warned_guess_language:
-            LOG.warning(
-                "Voxtral backend does not provide native language identification. Use language_backend='mms' for reliable code-switching."
-            )
+            LOG.warning("Voxtral backend does not provide native language identification. Use language_backend='mms' for reliable code-switching.")
             self._warned_guess_language = True
         return lang[0], 0.0
 

--- a/verbatim_batch/main.py
+++ b/verbatim_batch/main.py
@@ -8,12 +8,15 @@ from typing import Iterable, List
 
 # pylint: disable=import-outside-toplevel
 from verbatim_cli.args import add_shared_arguments
-from verbatim_cli.config_file import load_config_file, merge_args, select_profile
+from verbatim_cli.config_file import find_legacy_config_keys, load_config_file, merge_args, select_profile
 from verbatim_cli.configure import (
+    apply_env_defaults,
     build_output_formats,
     build_prefixes,
-    compute_log_level,
     make_config,
+    make_source_config,
+    resolve_log_level,
+    resolve_speakers,
 )
 from verbatim_cli.env import load_env_file
 from verbatim_cli.run_single import run_single_input
@@ -82,10 +85,58 @@ def outputs_exist(output_prefix_no_ext: str, output_formats: List[str]) -> bool:
     return False
 
 
+def _install_target_key(config, source_config) -> tuple:
+    return (
+        config.model_cache_dir,
+        config.stream,
+        config.transcriber_backend,
+        config.whisper_model_size,
+        config.qwen_asr_model_size,
+        config.qwen_aligner_model_size,
+        config.voxtral_model_size,
+        config.language_identifier_backend,
+        config.mms_lid_model_size,
+        config.non_speech_backend,
+        config.ast_audio_model_size,
+        source_config.diarize_strategy,
+        source_config.isolate,
+    )
+
+
+def collect_install_targets(
+    *,
+    base_defaults: Namespace,
+    user_args: Namespace,
+    cfg_data: dict,
+    global_profile: dict,
+    inputs: Iterable[Path],
+) -> list[tuple]:
+    targets = []
+    seen: set[tuple] = set()
+    candidate_args = [merge_args(base_defaults, global_profile, user_args)]
+    for source_path in inputs:
+        profile = select_profile(cfg_data, filename=str(source_path))
+        candidate_args.append(merge_args(base_defaults, {**global_profile, **profile}, user_args))
+
+    for candidate in candidate_args:
+        resolved_args = apply_env_defaults(candidate, base_defaults)
+        speakers = resolve_speakers(resolved_args)
+        config = make_config(resolved_args)
+        source_config = make_source_config(resolved_args, speakers=speakers)
+        key = _install_target_key(config, source_config)
+        if key in seen:
+            continue
+        seen.add(key)
+        targets.append((config, source_config))
+    return targets
+
+
 def main():
     parser = build_batch_parser()
     base_defaults: Namespace = parser.parse_args([])
     user_args = parser.parse_args()
+
+    load_env_file()
 
     cfg_data = {}
     if getattr(user_args, "config", None):
@@ -93,8 +144,9 @@ def main():
 
     global_profile = select_profile(cfg_data, filename=None)
     args = merge_args(base_defaults, global_profile, user_args)
+    args = apply_env_defaults(args, base_defaults)
 
-    log_level = compute_log_level(args.verbose)
+    log_level = resolve_log_level(args, base_defaults)
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
     logging.basicConfig(
@@ -104,18 +156,15 @@ def main():
         datefmt="%Y-%m-%dT%H:%M:%SZ",
     )
 
-    load_env_file()
-
-    # Handle install-only mode
-    if args.install:
-        LOG.info("Installing/prefetching models into cache...")
-        from verbatim.prefetch import prefetch
-
-        # Use default whisper model size from a temporary config
-        cfg = make_config(args)
-        prefetch(model_cache_dir=args.model_cache, whisper_size=cfg.whisper_model_size)
-        LOG.info("Model prefetch complete.")
-        return
+    if cfg_data and getattr(user_args, "config", None):
+        for path, replacement in find_legacy_config_keys(cfg_data):
+            LOG.warning(
+                "Config file %s uses deprecated key '%s'; use '%s' instead. "
+                "This warning shim will be removed in the next minor version bump.",
+                user_args.config,
+                path,
+                replacement,
+            )
 
     if not args.batch_dir:
         parser.error("Batch directory must be specified via --batch-dir or config file")
@@ -127,6 +176,23 @@ def main():
     inputs = iter_input_files(batch_dir, include_patterns, args.recursive)
     if args.ignore:
         inputs = filter_input_files(inputs, args.ignore, batch_dir=batch_dir)
+
+    # Handle install-only mode
+    if args.install:
+        LOG.info("Installing/prefetching models into cache...")
+        from verbatim.prefetch import prefetch
+
+        install_targets = collect_install_targets(
+            base_defaults=base_defaults,
+            user_args=user_args,
+            cfg_data=cfg_data,
+            global_profile=global_profile,
+            inputs=inputs,
+        )
+        for config, source_config in install_targets:
+            prefetch(config=config, source_config=source_config)
+        LOG.info("Model prefetch complete for %d effective batch configuration(s).", len(install_targets))
+        return
     if not inputs:
         LOG.info("No input files found under %s with patterns %s", batch_dir, include_patterns)
         return
@@ -138,6 +204,7 @@ def main():
 
         profile = select_profile(cfg_data, filename=source_path)
         file_args = merge_args(base_defaults, {**global_profile, **profile}, user_args)
+        file_args = apply_env_defaults(file_args, base_defaults)
 
         config = make_config(file_args)
         output_formats = build_output_formats(file_args, default_stdout=False)

--- a/verbatim_batch/main.py
+++ b/verbatim_batch/main.py
@@ -159,8 +159,7 @@ def main():
     if cfg_data and getattr(user_args, "config", None):
         for path, replacement in find_legacy_config_keys(cfg_data):
             LOG.warning(
-                "Config file %s uses deprecated key '%s'; use '%s' instead. "
-                "This warning shim will be removed in the next minor version bump.",
+                "Config file %s uses deprecated key '%s'; use '%s' instead. This warning shim will be removed in the next minor version bump.",
                 user_args.config,
                 path,
                 replacement,

--- a/verbatim_cli/args.py
+++ b/verbatim_cli/args.py
@@ -77,7 +77,13 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
     parser.add_argument("--cpu", action="store_true", help="Toggle CPU usage")
     parser.add_argument("-s", "--stream", action="store_true", help="Set mode to low latency streaming")
     parser.add_argument("--offline", action="store_true", help="Disallow any network/model downloads; use cache only")
-    parser.add_argument("--modeldir", default=None, help="Deterministic model/cache directory for models and downloads")
+    parser.add_argument(
+        "--modeldir",
+        "--model-cache",
+        dest="modeldir",
+        default=None,
+        help="Deterministic model/cache directory for models and downloads",
+    )
     parser.add_argument(
         "--asr-model",
         default=None,

--- a/verbatim_cli/args.py
+++ b/verbatim_cli/args.py
@@ -73,19 +73,15 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
     )
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity (specify multiple times for more verbosity)")
     parser.add_argument("--version", action="version", version=f"{prog} {__version__}")
+    parser.add_argument("--device", choices=["auto", "cpu", "cuda", "mps"], default="auto", help="Execution device to use")
     parser.add_argument("--cpu", action="store_true", help="Toggle CPU usage")
     parser.add_argument("-s", "--stream", action="store_true", help="Set mode to low latency streaming")
     parser.add_argument("--offline", action="store_true", help="Disallow any network/model downloads; use cache only")
-    parser.add_argument("--model-cache", default=None, help="Deterministic cache directory for models and downloads")
+    parser.add_argument("--modeldir", default=None, help="Deterministic model/cache directory for models and downloads")
     parser.add_argument(
-        "--whisper-model",
+        "--asr-model",
         default=None,
-        help="Whisper model size or path (e.g., 'large-v3' or 'nyrahealth/faster_CrisperWhisper')",
-    )
-    parser.add_argument(
-        "--voxtral-model",
-        default=None,
-        help="Voxtral model id or path (e.g., 'mistralai/Voxtral-Mini-3B-2507')",
+        help="ASR model id or path for the active ASR backend (for example Whisper or Qwen ASR).",
     )
     parser.add_argument(
         "--voxtral-max-new-tokens",
@@ -94,13 +90,14 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         help="Maximum number of generated tokens for the Voxtral transcription backend.",
     )
     parser.add_argument(
-        "--transcriber-backend",
+        "--asr-backend",
         choices=["auto", "qwen", "qwen-asr", "voxtral"],
         default=None,
-        help="Transcription backend to use. Defaults to the standard Whisper backend when unset.",
+        help="ASR backend to use. Defaults to the standard Whisper backend when unset.",
     )
     parser.add_argument(
-        "--language-identifier-backend",
+        "--language-backend",
+        dest="language_backend",
         choices=["transcriber", "mms"],
         default=None,
         help="Language identification backend to use. 'transcriber' uses the active ASR backend; 'mms' uses facebook/mms-lid-126.",
@@ -124,12 +121,14 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         help="Multiplicative growth factor for language detection retries (default: 2.0, clamped to >= 1.0).",
     )
     parser.add_argument(
-        "--mms-lid-model-size",
+        "--language-model",
+        dest="language_model",
         default=None,
-        help="Model id or path for the MMS language identification backend.",
+        help="Model id or path for the active language identification backend.",
     )
     parser.add_argument(
-        "--non-speech-backend",
+        "--non-vad-backend",
+        dest="vad_backend",
         choices=["energy", "ast"],
         default=None,
         help=(
@@ -139,9 +138,10 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         ),
     )
     parser.add_argument(
-        "--ast-audio-model-size",
+        "--noise-model",
+        dest="noise_model",
         default=None,
-        help="Model id or path for the AST non-speech classification backend.",
+        help="Model id or path for the active noise/non-speech classification backend.",
     )
     parser.add_argument(
         "--code-switching",
@@ -156,13 +156,13 @@ def add_shared_arguments(parser: argparse.ArgumentParser, *, include_input: bool
         default=None,
         help=(
             "Password for encrypted DSS/DS2 input. Less safe than env/config because it can leak via shell history or process listings; "
-            "prefer VERBATIM_DSS_PASSWORD or a config file."
+            "prefer VERBATIM_AUDIO_PASSWORD or a config file."
         ),
     )
     parser.add_argument(
         "--install",
         action="store_true",
-        help="Prefetch commonly used models into the cache and exit",
+        help="Prefetch the models required by the current effective configuration into the cache and exit",
     )
     parser.add_argument(
         "-w",

--- a/verbatim_cli/config_file.py
+++ b/verbatim_cli/config_file.py
@@ -14,6 +14,18 @@ from verbatim_files.format.writer import LanguageStyle, ProbabilityStyle, Speake
 
 OUTPUT_FLAGS = ("ass", "docx", "txt", "json", "jsonl", "md")
 DEFAULT_MATCH = ["*.wav", "*.mp3", "*.m4a", "*.mp4"]
+# Temporary legacy config warning shim. Remove on the next minor-version cleanup.
+LEGACY_CONFIG_KEY_RENAMES = {
+    "transcriber_backend": "asr_backend",
+    "language_identifier_backend": "language_backend",
+    "mms_lid_model_size": "language_model",
+    "non_speech_backend": "vad_backend",
+    "ast_audio_model_size": "noise_model",
+    "whisper_model": "asr_model",
+    "whisper_model_size": "asr_model",
+    "voxtral_model": "asr_model",
+    "voxtral_model_size": "asr_model",
+}
 
 
 def load_config_file(path: str) -> Dict[str, Any]:
@@ -74,6 +86,24 @@ def _flatten_format(format_section: Dict[str, Any]) -> Dict[str, Any]:
 def flatten_profile(profile: Dict[str, Any]) -> Dict[str, Any]:
     flat: Dict[str, Any] = {}
     for key, val in profile.items():
+        if key == "asr_backend":
+            flat["asr_backend"] = val
+            continue
+        if key == "language_model":
+            flat["language_model"] = val
+            continue
+        if key == "language_backend":
+            flat["language_backend"] = val
+            continue
+        if key == "vad_backend":
+            flat["vad_backend"] = val
+            continue
+        if key == "noise_model":
+            flat["noise_model"] = val
+            continue
+        if key == "asr_model":
+            flat["asr_model"] = val
+            continue
         if key == "match":
             if isinstance(val, dict):
                 filenames = val.get("filename")
@@ -100,6 +130,23 @@ def flatten_profile(profile: Dict[str, Any]) -> Dict[str, Any]:
             continue
         flat[key] = val
     return _normalize_styles(flat)
+
+
+def find_legacy_config_keys(config_data: Any, *, _prefix: str = "") -> list[tuple[str, str]]:
+    findings: list[tuple[str, str]] = []
+    if isinstance(config_data, dict):
+        for key, value in config_data.items():
+            path = f"{_prefix}.{key}" if _prefix else key
+            replacement = LEGACY_CONFIG_KEY_RENAMES.get(key)
+            if replacement:
+                findings.append((path, replacement))
+            findings.extend(find_legacy_config_keys(value, _prefix=path))
+        return findings
+    if isinstance(config_data, list):
+        for index, value in enumerate(config_data):
+            path = f"{_prefix}[{index}]" if _prefix else f"[{index}]"
+            findings.extend(find_legacy_config_keys(value, _prefix=path))
+    return findings
 
 
 def _match_profile(profile: Dict[str, Any], filename: Optional[str]) -> bool:

--- a/verbatim_cli/config_file.py
+++ b/verbatim_cli/config_file.py
@@ -206,15 +206,18 @@ def select_profile(config_data: Dict[str, Any], filename: Optional[str]) -> Dict
 
 def merge_args(base_defaults: Namespace, profile_overrides: Dict[str, Any], user_args: Namespace) -> Namespace:
     merged = vars(base_defaults).copy()
+    explicit_args = set(profile_overrides.keys())
     merged.update(profile_overrides)
     for key, val in vars(user_args).items():
         # Only override when the user provided a value different from the parser default
         if key in merged and val == getattr(base_defaults, key, None):
             continue
         merged[key] = val
+        explicit_args.add(key)
     # If match/ignore not specified by user or profile, ensure defaults
     if "match" not in merged or merged["match"] is None:
         merged["match"] = DEFAULT_MATCH
     if "ignore" not in merged or merged["ignore"] is None:
         merged["ignore"] = []
+    merged["_explicit_args"] = explicit_args
     return argparse.Namespace(**merged)

--- a/verbatim_cli/configure.py
+++ b/verbatim_cli/configure.py
@@ -41,6 +41,16 @@ def _parse_int_env_value(value: str) -> int:
 
 
 def _uses_default(args: Namespace, base_defaults: Namespace, arg_name: str) -> bool:
+    explicit_args = getattr(args, "_explicit_args", set())
+    if arg_name in explicit_args:
+        return False
+    if hasattr(args, "_get_kwargs"):
+        current_value = getattr(args, arg_name, None)
+        default_value = getattr(base_defaults, arg_name, None)
+        if current_value == default_value:
+            option_string = f"--{arg_name.replace('_', '-')}"
+            if option_string in " ".join([]):
+                return False
     return getattr(args, arg_name, None) == getattr(base_defaults, arg_name, None)
 
 

--- a/verbatim_cli/configure.py
+++ b/verbatim_cli/configure.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from argparse import Namespace
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, cast
 
 from verbatim.config import Config
 from verbatim_audio.sources.sourceconfig import SourceConfig
@@ -196,7 +196,7 @@ def _parse_log_level(value: str) -> int:
     normalized = aliases.get(normalized, normalized)
     if normalized.isdigit():
         return int(normalized)
-    mapping: Callable[[], dict] = getattr(logging, "getLevelNamesMapping", None)
+    mapping = cast(Optional[Callable[[], dict[str, int]]], getattr(logging, "getLevelNamesMapping", None))
     if mapping is not None:
         level = mapping().get(normalized)
         if isinstance(level, int):

--- a/verbatim_cli/configure.py
+++ b/verbatim_cli/configure.py
@@ -2,13 +2,199 @@
 
 import logging
 import os
-from typing import List, Optional
+from argparse import Namespace
+from typing import Callable, List, Optional
 
 from verbatim.config import Config
 from verbatim_audio.sources.sourceconfig import SourceConfig
 from verbatim_files.format.writer import TranscriptWriterConfig
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_env_value(*env_names: str) -> Optional[str]:
+    for env_name in env_names:
+        env_value = os.getenv(env_name)
+        if env_value:
+            return env_value
+    return None
+
+
+def _resolve_env_override(args, arg_name: str, *env_names: str) -> Optional[str]:
+    value = getattr(args, arg_name, None)
+    if value:
+        return value
+    return _get_env_value(*env_names)
+
+
+def _parse_bool_env_value(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in ("1", "true", "yes", "y", "on"):
+        return True
+    if lowered in ("0", "false", "no", "n", "off"):
+        return False
+    raise ValueError(f"Invalid boolean environment value: {value}")
+
+
+def _parse_int_env_value(value: str) -> int:
+    return int(value.strip())
+
+
+def _uses_default(args: Namespace, base_defaults: Namespace, arg_name: str) -> bool:
+    return getattr(args, arg_name, None) == getattr(base_defaults, arg_name, None)
+
+
+def _apply_string_env_default(args: Namespace, base_defaults: Namespace, arg_name: str, *env_names: str) -> None:
+    if not _uses_default(args, base_defaults, arg_name):
+        return
+    env_value = _get_env_value(*env_names)
+    if env_value:
+        setattr(args, arg_name, env_value)
+
+
+def _apply_bool_env_default(args: Namespace, base_defaults: Namespace, arg_name: str, *env_names: str) -> None:
+    if not _uses_default(args, base_defaults, arg_name):
+        return
+    env_value = _get_env_value(*env_names)
+    if env_value is None:
+        return
+    setattr(args, arg_name, _parse_bool_env_value(env_value))
+
+
+def _apply_int_env_default(args: Namespace, base_defaults: Namespace, arg_name: str, *env_names: str) -> None:
+    if not _uses_default(args, base_defaults, arg_name):
+        return
+    env_value = _get_env_value(*env_names)
+    if env_value is None:
+        return
+    setattr(args, arg_name, _parse_int_env_value(env_value))
+
+
+def apply_env_defaults(args: Namespace, base_defaults: Namespace) -> Namespace:
+    for arg_name, env_name in (
+        ("device", "VERBATIM_DEVICE"),
+        ("modeldir", "VERBATIM_MODELDIR"),
+        ("workdir", "VERBATIM_WORKDIR"),
+        ("log_file", "VERBATIM_LOG_FILE"),
+        ("outdir", "VERBATIM_OUTDIR"),
+        ("asr_backend", "VERBATIM_ASR_BACKEND"),
+        ("language_backend", "VERBATIM_LANGUAGE_BACKEND"),
+        ("language_model", "VERBATIM_LANGUAGE_MODEL"),
+        ("diarize", "VERBATIM_DIARIZE"),
+        ("asr_model", "VERBATIM_ASR_MODEL"),
+        ("vad_backend", "VERBATIM_VAD_BACKEND"),
+        ("noise_model", "VERBATIM_NOISE_MODEL"),
+    ):
+        _apply_string_env_default(args, base_defaults, arg_name, env_name)
+
+    if _uses_default(args, base_defaults, "password"):
+        audio_password = _get_env_value("VERBATIM_AUDIO_PASSWORD")
+        if audio_password:
+            args.password = audio_password
+
+    _apply_bool_env_default(args, base_defaults, "offline", "VERBATIM_OFFLINE")
+    _apply_bool_env_default(args, base_defaults, "code_switching", "VERBATIM_CODE_SWITCHING")
+    _apply_int_env_default(args, base_defaults, "voxtral_max_new_tokens", "VERBATIM_VOXTRAL_MAX_NEW_TOKENS")
+    return args
+
+
+def resolve_audio_password(args) -> Optional[str]:
+    cli_password = getattr(args, "password", None)
+    if cli_password:
+        return cli_password
+    return _get_env_value("VERBATIM_AUDIO_PASSWORD")
+
+
+def resolve_asr_backend(args) -> Optional[str]:
+    return _resolve_env_override(args, "asr_backend", "VERBATIM_ASR_BACKEND")
+
+
+def resolve_language_backend(args) -> Optional[str]:
+    return _resolve_env_override(args, "language_backend", "VERBATIM_LANGUAGE_BACKEND")
+
+
+def resolve_language_model(args) -> Optional[str]:
+    return _resolve_env_override(args, "language_model", "VERBATIM_LANGUAGE_MODEL")
+
+
+def resolve_diarize_strategy(args) -> Optional[str]:
+    diarize_strategy = getattr(args, "diarize_policy", None) or getattr(args, "diarize", None)
+    if diarize_strategy:
+        return diarize_strategy
+    return _get_env_value("VERBATIM_DIARIZE")
+
+
+def resolve_asr_model(args) -> Optional[str]:
+    return _resolve_env_override(args, "asr_model", "VERBATIM_ASR_MODEL")
+
+
+def resolve_device(args) -> str:
+    if getattr(args, "cpu", False):
+        return "cpu"
+    return getattr(args, "device", "auto") or "auto"
+
+
+def resolve_vad_backend(args) -> Optional[str]:
+    return _resolve_env_override(args, "vad_backend", "VERBATIM_VAD_BACKEND")
+
+
+def resolve_noise_model(args) -> Optional[str]:
+    return _resolve_env_override(args, "noise_model", "VERBATIM_NOISE_MODEL")
+
+
+def resolve_log_level(args: Namespace, base_defaults: Namespace) -> int:
+    if not _uses_default(args, base_defaults, "verbose"):
+        return compute_log_level(args.verbose)
+
+    env_level = os.getenv("VERBATIM_LOG_LEVEL")
+    if not env_level:
+        return compute_log_level(args.verbose)
+
+    try:
+        return _parse_log_level(env_level)
+    except ValueError:
+        LOG.warning("Ignoring invalid VERBATIM_LOG_LEVEL=%s", env_level)
+        return compute_log_level(args.verbose)
+
+
+def resolve_status_verbose(args: Namespace, base_defaults: Namespace) -> int:
+    if not _uses_default(args, base_defaults, "verbose"):
+        return args.verbose
+
+    env_level = os.getenv("VERBATIM_LOG_LEVEL")
+    if not env_level:
+        return args.verbose
+
+    try:
+        log_level = _parse_log_level(env_level)
+    except ValueError:
+        return args.verbose
+
+    if log_level <= logging.DEBUG:
+        return 2
+    if log_level <= logging.INFO:
+        return 1
+    return 0
+
+
+def _parse_log_level(value: str) -> int:
+    normalized = value.strip().upper()
+    aliases = {
+        "WARN": "WARNING",
+        "FATAL": "CRITICAL",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized.isdigit():
+        return int(normalized)
+    mapping: Callable[[], dict] = getattr(logging, "getLevelNamesMapping", None)
+    if mapping is not None:
+        level = mapping().get(normalized)
+        if isinstance(level, int):
+            return level
+    legacy_level = logging.getLevelName(normalized)
+    if isinstance(legacy_level, int):
+        return legacy_level
+    raise ValueError(f"Unknown log level: {value}")
 
 
 def compute_log_level(verbose: int) -> int:
@@ -21,37 +207,47 @@ def compute_log_level(verbose: int) -> int:
 
 def make_config(args) -> Config:
     config: Config = Config(
-        device="cpu" if args.cpu else "auto",
+        device=resolve_device(args),
         output_dir=args.outdir,
         working_dir=args.workdir,
         stream=args.stream,
         offline=args.offline,
-        model_cache_dir=args.model_cache,
+        model_cache_dir=args.modeldir,
         log_file=getattr(args, "log_file", None),
         log_colours=not bool(getattr(args, "log_file", None)),
     )
-    if getattr(args, "whisper_model", None):
-        config.whisper_model_size = args.whisper_model
-    if getattr(args, "voxtral_model", None):
-        config.voxtral_model_size = args.voxtral_model
+    asr_backend = resolve_asr_backend(args) or config.transcriber_backend
+    asr_model = resolve_asr_model(args)
+    if asr_model:
+        normalized_backend = (asr_backend or "auto").lower()
+        if normalized_backend in ("qwen", "qwen-asr"):
+            config.qwen_asr_model_size = asr_model
+        elif normalized_backend == "voxtral":
+            config.voxtral_model_size = asr_model
+        else:
+            config.whisper_model_size = asr_model
     if getattr(args, "voxtral_max_new_tokens", None) is not None:
         config.voxtral_max_new_tokens = args.voxtral_max_new_tokens
-    if getattr(args, "transcriber_backend", None):
-        config.transcriber_backend = args.transcriber_backend
-    if getattr(args, "language_identifier_backend", None):
-        config.language_identifier_backend = args.language_identifier_backend
+    if asr_backend:
+        config.transcriber_backend = asr_backend
+    language_backend = resolve_language_backend(args)
+    if language_backend:
+        config.language_identifier_backend = language_backend
     if getattr(args, "language_detection_initial_seconds", None) is not None:
         config.language_detection_initial_seconds = args.language_detection_initial_seconds
     if getattr(args, "language_detection_increment_seconds", None) is not None:
         config.language_detection_increment_seconds = args.language_detection_increment_seconds
     if getattr(args, "language_detection_factor", None) is not None:
         config.language_detection_factor = args.language_detection_factor
-    if getattr(args, "mms_lid_model_size", None):
-        config.mms_lid_model_size = args.mms_lid_model_size
-    if getattr(args, "non_speech_backend", None):
-        config.non_speech_backend = args.non_speech_backend
-    if getattr(args, "ast_audio_model_size", None):
-        config.ast_audio_model_size = args.ast_audio_model_size
+    language_model = resolve_language_model(args)
+    if language_model:
+        config.mms_lid_model_size = language_model
+    vad_backend = resolve_vad_backend(args)
+    if vad_backend:
+        config.non_speech_backend = vad_backend
+    noise_model = resolve_noise_model(args)
+    if noise_model:
+        config.ast_audio_model_size = noise_model
     if getattr(args, "code_switching", None) is not None:
         config.code_switching = args.code_switching
     config.lang = args.languages if args.languages else ["en"]
@@ -83,9 +279,9 @@ def make_source_config(args, speakers: Optional[int]) -> SourceConfig:
     vttm_path = args.vttm if args.vttm not in (None, "") else None
     return SourceConfig(
         isolate=args.isolate,
-        diarize_strategy=args.diarize_policy or args.diarize,
+        diarize_strategy=resolve_diarize_strategy(args),
         speakers=speakers,
-        password=getattr(args, "password", None) or os.getenv("VERBATIM_DSS_PASSWORD"),
+        password=resolve_audio_password(args),
         diarization_file=args.diarization,
         vttm_file=vttm_path,
     )

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -38,10 +38,6 @@ def main():
     args = merge_args(base_defaults, profile_overrides, user_args)
     args = apply_env_defaults(args, base_defaults)
 
-    if not args.input:
-        parser.error("Input audio file must be specified")
-    source_path: str = cast(str, args.input)
-
     log_level = resolve_log_level(args, base_defaults)
     status_verbose = resolve_status_verbose(args, base_defaults)
     for handler in logging.root.handlers[:]:
@@ -97,7 +93,7 @@ def main():
         status_log.info("Model prefetch complete.")
         return
 
-    source_path = cast(str, args.input)
+    source_path: str = cast(str, args.input)
     speakers = resolve_speakers(args)
 
     status_log.info(

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -37,6 +37,10 @@ def main():
     args = merge_args(base_defaults, profile_overrides, user_args)
     args = apply_env_defaults(args, base_defaults)
 
+    if not args.input:
+        parser.error("Input audio file must be specified")
+    source_path = args.input
+
     log_level = resolve_log_level(args, base_defaults)
     status_verbose = resolve_status_verbose(args, base_defaults)
     for handler in logging.root.handlers[:]:

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -66,8 +66,7 @@ def main():
     if cfg_data and getattr(user_args, "config", None):
         for path, replacement in find_legacy_config_keys(cfg_data):
             LOG.warning(
-                "Config file %s uses deprecated key '%s'; use '%s' instead. "
-                "This warning shim will be removed in the next minor version bump.",
+                "Config file %s uses deprecated key '%s'; use '%s' instead. This warning shim will be removed in the next minor version bump.",
                 user_args.config,
                 path,
                 replacement,

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -10,11 +10,14 @@ def main():
 
     from verbatim.logging_utils import configure_status_logger, get_status_logger
     from verbatim_cli.args import build_parser
-    from verbatim_cli.config_file import load_config_file, merge_args, select_profile
+    from verbatim_cli.config_file import find_legacy_config_keys, load_config_file, merge_args, select_profile
     from verbatim_cli.configure import (
-        compute_log_level,
+        apply_env_defaults,
         make_config,
+        make_source_config,
+        resolve_log_level,
         resolve_speakers,
+        resolve_status_verbose,
     )
     from verbatim_cli.env import load_env_file
     from verbatim_cli.run_single import run_single_input
@@ -23,14 +26,19 @@ def main():
     base_defaults: Namespace = parser.parse_args([])
     user_args = parser.parse_args()
 
+    # Load the values from the .env file, if present, before resolving env-backed defaults.
+    load_env_file()
+
     cfg_data = {}
     if getattr(user_args, "config", None):
         cfg_data = load_config_file(user_args.config)
 
     profile_overrides = select_profile(cfg_data, filename=user_args.input)
     args = merge_args(base_defaults, profile_overrides, user_args)
+    args = apply_env_defaults(args, base_defaults)
 
-    log_level = compute_log_level(args.verbose)
+    log_level = resolve_log_level(args, base_defaults)
+    status_verbose = resolve_status_verbose(args, base_defaults)
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
 
@@ -48,15 +56,22 @@ def main():
         handlers.append(file_handler)
 
         status_file_handler = logging.FileHandler(args.log_file, mode="a", encoding="utf-8")
-        status_file_handler.setLevel(logging.DEBUG if args.verbose >= 2 else logging.INFO)
+        status_file_handler.setLevel(logging.DEBUG if status_verbose >= 2 else logging.INFO)
         status_file_handler.setFormatter(formatter)
 
     logging.basicConfig(level=log_level, handlers=handlers, force=True)
-    configure_status_logger(verbose=args.verbose, fmt=log_format, datefmt="%Y-%m-%dT%H:%M:%SZ", file_handler=status_file_handler)
+    configure_status_logger(verbose=status_verbose, fmt=log_format, datefmt="%Y-%m-%dT%H:%M:%SZ", file_handler=status_file_handler)
     status_log = get_status_logger()
 
-    # load the values from the .env file, if present
-    load_env_file()
+    if cfg_data and getattr(user_args, "config", None):
+        for path, replacement in find_legacy_config_keys(cfg_data):
+            LOG.warning(
+                "Config file %s uses deprecated key '%s'; use '%s' instead. "
+                "This warning shim will be removed in the next minor version bump.",
+                user_args.config,
+                path,
+                replacement,
+            )
 
     # Check if the version option is specified
     if hasattr(args, "version") and args.version:
@@ -74,7 +89,7 @@ def main():
         status_log.info("Installing/prefetching models into cache...")
         from verbatim.prefetch import prefetch
 
-        prefetch(model_cache_dir=args.model_cache, whisper_size=config.whisper_model_size)
+        prefetch(config=config, source_config=make_source_config(args, speakers=resolve_speakers(args)))
         status_log.info("Model prefetch complete.")
         return
 

--- a/verbatim_cli/main.py
+++ b/verbatim_cli/main.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import cast
 
 LOG = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ def main():
 
     if not args.input:
         parser.error("Input audio file must be specified")
-    source_path = args.input
+    source_path: str = cast(str, args.input)
 
     log_level = resolve_log_level(args, base_defaults)
     status_verbose = resolve_status_verbose(args, base_defaults)
@@ -96,7 +97,7 @@ def main():
         status_log.info("Model prefetch complete.")
         return
 
-    source_path = args.input
+    source_path = cast(str, args.input)
     speakers = resolve_speakers(args)
 
     status_log.info(

--- a/verbatim_diarization/prefetch.py
+++ b/verbatim_diarization/prefetch.py
@@ -8,7 +8,12 @@ from typing import Optional
 LOG = logging.getLogger(__name__)
 
 
-def prefetch_diarization_models(hf_token: Optional[str] = None, cache_dir: Optional[str] = None, offline: bool = False) -> None:
+def prefetch_diarization_models(
+    hf_token: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    offline: bool = False,
+    include_separation: bool = True,
+) -> None:
     """Prefetch diarization/separation models (pyannote).
 
     Expects cache/offline environment variables to be set by the caller.
@@ -28,10 +33,11 @@ def prefetch_diarization_models(hf_token: Optional[str] = None, cache_dir: Optio
         PYANNOTE_SEPARATION_MODEL_REVISION,
     )
 
-    repos = (
+    repos = [
         (PYANNOTE_DIARIZATION_MODEL_ID, PYANNOTE_DIARIZATION_MODEL_REVISION),
-        (PYANNOTE_SEPARATION_MODEL_ID, PYANNOTE_SEPARATION_MODEL_REVISION),
-    )
+    ]
+    if include_separation:
+        repos.append((PYANNOTE_SEPARATION_MODEL_ID, PYANNOTE_SEPARATION_MODEL_REVISION))
     for repo, revision in repos:
         pinned_revision = revision or "refs/heads/main"
         try:

--- a/verbatim_diarization/pyannote/diarize.py
+++ b/verbatim_diarization/pyannote/diarize.py
@@ -60,13 +60,13 @@ class PyAnnoteDiarization(DiarizationStrategy):
             )
             self.pipeline = Pipeline.from_pretrained(
                 pipeline_path,
-                use_auth_token=self.huggingface_token or None,
+                token=self.huggingface_token or None,
                 cache_dir=get_pyannote_cache_dir(),
             )
         if self.pipeline is None:
             raise RuntimeError("PyAnnote pipeline failed to initialize")
         self.pipeline.instantiate({})
-        self.pipeline.to(torch.device(self.device))
+        self.pipeline.to(torch.device(self.device))  # pyright: ignore[reportPrivateImportUsage]
 
     # pylint: disable=too-many-positional-arguments
     def compute_diarization(
@@ -105,7 +105,7 @@ class PyAnnoteDiarization(DiarizationStrategy):
                 else:
                     mono = audio
 
-                waveform = torch.from_numpy(constrain_audio_range(np.asarray(mono, dtype=np.float32)))
+                waveform = torch.as_tensor(constrain_audio_range(np.asarray(mono, dtype=np.float32)))  # pyright: ignore[reportPrivateImportUsage]
                 if waveform.ndim == 1:
                     waveform = waveform.unsqueeze(0)
                 # Feed the pipeline an in-memory waveform directly so pyannote does not need

--- a/verbatim_diarization/pyannote/diarize.py
+++ b/verbatim_diarization/pyannote/diarize.py
@@ -5,7 +5,7 @@ import sys
 import time
 from typing import Any, Optional
 
-# pylint: disable=import-outside-toplevel,broad-exception-caught
+# pylint: disable=import-outside-toplevel,broad-exception-caught,unexpected-keyword-arg
 import numpy as np
 import torch
 from pyannote.audio import Pipeline
@@ -15,6 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
+from verbatim.model_cache import get_pyannote_cache_dir, resolve_hf_file_path
 from verbatim_audio.audio import constrain_audio_range
 from verbatim_diarization.diarize.base import DiarizationStrategy
 from verbatim_diarization.pyannote.progress import StatusProgressHook
@@ -24,7 +25,7 @@ from verbatim_diarization.utils import sanitize_uri_component
 from verbatim_files.rttm import Annotation as RTTMAnnotation
 from verbatim_files.vttm import AudioRef, dumps_vttm
 
-from .constants import PYANNOTE_DIARIZATION_MODEL_ID
+from .constants import PYANNOTE_DIARIZATION_MODEL_ID, PYANNOTE_DIARIZATION_MODEL_REVISION
 from .output import select_speaker_diarization
 
 LOG = logging.getLogger(__name__)
@@ -49,7 +50,19 @@ class PyAnnoteDiarization(DiarizationStrategy):
                 safe_types.append(torch_version_mod.TorchVersion)  # type: ignore[attr-defined]
             add_safe_globals(safe_types)  # pyright: ignore[reportArgumentType]
             # Default to community-friendly model
-            self.pipeline = Pipeline.from_pretrained(self.model_id, token=self.huggingface_token)
+            pipeline_path = resolve_hf_file_path(
+                self.model_id,
+                filename="config.yaml",
+                purpose="pyannote diarization model",
+                cache_dir=get_pyannote_cache_dir(),
+                revision=PYANNOTE_DIARIZATION_MODEL_REVISION,
+                token=self.huggingface_token or None,
+            )
+            self.pipeline = Pipeline.from_pretrained(
+                pipeline_path,
+                use_auth_token=self.huggingface_token or None,
+                cache_dir=get_pyannote_cache_dir(),
+            )
         if self.pipeline is None:
             raise RuntimeError("PyAnnote pipeline failed to initialize")
         self.pipeline.instantiate({})

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -78,7 +78,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
         )
         self.pipeline = Pipeline.from_pretrained(
             pipeline_path,
-            use_auth_token=self.huggingface_token or None,
+            token=self.huggingface_token or None,
             cache_dir=get_pyannote_cache_dir(),
         )
         hyper_parameters = {
@@ -98,7 +98,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             raise RuntimeError("Pyannote separation pipeline failed to initialize")
 
         self.pipeline.instantiate(hyper_parameters)
-        self.pipeline.to(torch.device(device))
+        self.pipeline.to(torch.device(device))  # pyright: ignore[reportPrivateImportUsage]
 
     def __enter__(self) -> "PyannoteSpeakerSeparation":
         return self
@@ -120,7 +120,7 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             else:
                 mono = audio
 
-            waveform = torch.from_numpy(constrain_audio_range(np.asarray(mono, dtype=np.float32)))
+            waveform = torch.as_tensor(constrain_audio_range(np.asarray(mono, dtype=np.float32)))  # pyright: ignore[reportPrivateImportUsage]
             if waveform.ndim == 1:
                 waveform = waveform.unsqueeze(0)
             return {"waveform": waveform, "sample_rate": int(sample_rate)}, None

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -5,7 +5,7 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-# pylint: disable=import-outside-toplevel,broad-exception-caught
+# pylint: disable=import-outside-toplevel,broad-exception-caught,unexpected-keyword-arg
 import numpy as np
 import torch
 from pyannote.audio import Pipeline
@@ -15,6 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
+from verbatim.model_cache import get_pyannote_cache_dir, resolve_hf_file_path
 from verbatim_audio.audio import constrain_audio_range, wav_to_int16
 from verbatim_audio.sources.audiosource import AudioSource
 from verbatim_audio.sources.fileaudiosource import FileAudioSource
@@ -24,7 +25,7 @@ from verbatim_files.rttm import Annotation as RTTMAnnotation
 from verbatim_files.rttm import Segment, dumps_rttm
 from verbatim_files.vttm import AudioRef, dumps_vttm
 
-from .constants import PYANNOTE_SEPARATION_MODEL_ID
+from .constants import PYANNOTE_SEPARATION_MODEL_ID, PYANNOTE_SEPARATION_MODEL_REVISION
 from .ffmpeg_loader import ensure_torchcodec_audio_decoder
 from .output import select_speaker_diarization
 from .progress import StatusProgressHook
@@ -67,7 +68,19 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             safe_types.append(torch_version_mod.TorchVersion)  # type: ignore[attr-defined]
         add_safe_globals(safe_types)  # pyright: ignore[reportArgumentType]
 
-        self.pipeline = Pipeline.from_pretrained(separation_model, token=self.huggingface_token)
+        pipeline_path = resolve_hf_file_path(
+            separation_model,
+            filename="config.yaml",
+            purpose="pyannote separation model",
+            cache_dir=get_pyannote_cache_dir(),
+            revision=PYANNOTE_SEPARATION_MODEL_REVISION,
+            token=self.huggingface_token or None,
+        )
+        self.pipeline = Pipeline.from_pretrained(
+            pipeline_path,
+            use_auth_token=self.huggingface_token or None,
+            cache_dir=get_pyannote_cache_dir(),
+        )
         hyper_parameters = {
             "segmentation": {"min_duration_off": 0.0, "threshold": 0.82},
             "clustering": {

--- a/verbatim_diarization/senko/diarize.py
+++ b/verbatim_diarization/senko/diarize.py
@@ -1,3 +1,6 @@
+"""Senko diarization adapter."""
+# pylint: disable=import-outside-toplevel
+
 import io
 import logging
 import os
@@ -65,8 +68,8 @@ class SenkoDiarization(DiarizationStrategy):
         if self._diarizer is not None:
             return self._diarizer
 
-        try:
-            import senko  # pylint: disable=import-outside-toplevel
+        try:  # pylint: disable=import-outside-toplevel
+            import senko
         except ImportError as exc:
             raise RuntimeError(
                 'Senko diarization requires the Senko package. Install it with `uv pip install "git+https://github.com/narcotic-sh/senko.git"`.'

--- a/verbatim_transcript/interfaces.py
+++ b/verbatim_transcript/interfaces.py
@@ -48,7 +48,7 @@ class VadProtocol(Protocol):
 VadFn = VadProtocol
 GuessLanguageFn = Callable[[NDArray, List[str]], Tuple[str, float]]
 
-TUtt_co = TypeVar("TUtt_co", covariant=True)  # pylint: disable=invalid-name
+TUtterance_co = TypeVar("TUtterance_co", covariant=True)  # pylint: disable=invalid-name
 TWord_co = TypeVar("TWord_co", covariant=True)  # pylint: disable=invalid-name
 
 
@@ -72,9 +72,9 @@ class LanguageDetectionResult:
 
 
 @dataclass
-class TranscriptionWindowResult(Generic[TUtt_co, TWord_co]):
-    utterance: TUtt_co
-    unacknowledged: Sequence[TUtt_co]
+class TranscriptionWindowResult(Generic[TUtterance_co, TWord_co]):
+    utterance: TUtterance_co
+    unacknowledged: Sequence[TUtterance_co]
     unconfirmed_words: Sequence[TWord_co]
 
     def as_tuple(self):


### PR DESCRIPTION
This pull request updates configuration and documentation to reflect new, more consistent naming for Verbatim's backend and model selection options, improves offline model caching instructions, and adds new CLI/device selection features. It also introduces or updates tests to cover legacy config detection and batch install target collection logic.

**Configuration and CLI option updates:**

* Renamed CLI/config/environment variables for backend and model selection to use consistent names: `asr_backend`, `language_backend`, `language_model`, `asr_model`, `vad_backend`, `noise_model`, and others. Deprecated legacy names like `transcriber_backend`, `language_identifier_backend`, and `mms_lid_model_size`. Updated all documentation and sample configs accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R195) [[2]](diffhunk://#diff-d2418fdfd951cf34759253e176353052c65c5bd47b9f5b8a9d052fea79cc3037L3-R11) [[3]](diffhunk://#diff-4c8913a4983249bba72db3244f60d9a9ab3e56c162e550d620f7bf756dadb77bL36-R38) [[4]](diffhunk://#diff-4c8913a4983249bba72db3244f60d9a9ab3e56c162e550d620f7bf756dadb77bL54-R56) [[5]](diffhunk://#diff-4c8913a4983249bba72db3244f60d9a9ab3e56c162e550d620f7bf756dadb77bL73-R75) [[6]](diffhunk://#diff-4c8913a4983249bba72db3244f60d9a9ab3e56c162e550d620f7bf756dadb77bL91-R93)
* Added new device selection option `--device <auto|cpu|cuda|mps>` to CLI and documented it. `--cpu` is now shorthand for `--device cpu`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R136-R140) [[2]](diffhunk://#diff-5d2cd7803dac6845f70b65bffe662f4c95ac03689dd859450936a251aca272aeR52) [[3]](diffhunk://#diff-5d2cd7803dac6845f70b65bffe662f4c95ac03689dd859450936a251aca272aeR99-R103)

**Offline model caching improvements:**

* Changed `--model-cache` to `--modeldir` and clarified that `--install` now prefetches models for the current effective configuration, not just a default set. Expanded documentation on how to prepare for offline use, including cache warming and model dependencies.

**Documentation and environment variable updates:**

* Updated environment variable names for encrypted audio password from `VERBATIM_DSS_PASSWORD` to `VERBATIM_AUDIO_PASSWORD` throughout documentation and tests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R85) [[2]](diffhunk://#diff-00f9b138fec7ebbeb4b361e6f3f2bfa44219729bccd833354b9d3b9aa07322bbL51-R51)
* Added documentation for precedence of CLI/config/env/defaults, and provided a full list of environment variables for backend/model selection.

**Testing improvements:**

* Added tests for legacy config key detection, ensuring users are warned about deprecated options.
* Added tests for batch install target collection to verify correct union of profiles and backend/model selection logic.

These changes ensure more predictable configuration, easier offline use, and improved clarity for both users and developers.