### PR TITLE
Ensure that all files from the model are installed when using local s…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .verbatim
             ~/.cache/huggingface
             ~/.cache/ctranslate2
             ~/.cache/whisper
@@ -88,6 +89,7 @@ jobs:
           uv pip install --system -r requirements.txt
 
       - name: Prefetch models into .verbatim cache
+        if: runner.os == 'Linux' && matrix.python-version == '3.11'
         shell: bash
         env:
           VERBATIM_OFFLINE: "0"
@@ -147,6 +149,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
+            .verbatim
             ~/.cache/huggingface
             ~/.cache/ctranslate2
             ~/.cache/whisper
@@ -161,14 +164,6 @@ jobs:
           python -m pip install -U pip uv
           uv pip install --system -r requirements.txt
           uv pip install --system coverage pytest
-
-      - name: Prefetch models into .verbatim cache
-        shell: bash
-        env:
-          VERBATIM_OFFLINE: "0"
-          HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
-        run: |
-          verbatim --install --modeldir "$GITHUB_WORKSPACE/.verbatim"
 
       - name: Create .coveragerc
         shell: bash

--- a/verbatim_diarization/pyannote/diarize.py
+++ b/verbatim_diarization/pyannote/diarize.py
@@ -15,7 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
-from verbatim.model_cache import get_pyannote_cache_dir, resolve_hf_file_path
+from verbatim.model_cache import get_pyannote_cache_dir, is_offline_mode, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim_audio.audio import constrain_audio_range
 from verbatim_diarization.diarize.base import DiarizationStrategy
 from verbatim_diarization.pyannote.progress import StatusProgressHook
@@ -50,18 +50,26 @@ class PyAnnoteDiarization(DiarizationStrategy):
                 safe_types.append(torch_version_mod.TorchVersion)  # type: ignore[attr-defined]
             add_safe_globals(safe_types)  # pyright: ignore[reportArgumentType]
             # Default to community-friendly model
-            pipeline_path = resolve_hf_file_path(
-                self.model_id,
-                filename="config.yaml",
-                purpose="pyannote diarization model",
-                cache_dir=get_pyannote_cache_dir(),
-                revision=PYANNOTE_DIARIZATION_MODEL_REVISION,
-                token=self.huggingface_token or None,
-            )
+            cache_dir = get_pyannote_cache_dir()
+            if is_offline_mode():
+                pipeline_path = resolve_hf_snapshot_path(
+                    self.model_id,
+                    purpose="pyannote diarization model",
+                    cache_dir=cache_dir,
+                    revision=PYANNOTE_DIARIZATION_MODEL_REVISION,
+                    token=self.huggingface_token or None,
+                )
+            else:
+                pipeline_path = prefetch_hf_snapshot(
+                    self.model_id,
+                    cache_dir=cache_dir,
+                    revision=PYANNOTE_DIARIZATION_MODEL_REVISION,
+                    token=self.huggingface_token or None,
+                )
             self.pipeline = Pipeline.from_pretrained(
                 pipeline_path,
                 token=self.huggingface_token or None,
-                cache_dir=get_pyannote_cache_dir(),
+                cache_dir=cache_dir,
             )
         if self.pipeline is None:
             raise RuntimeError("PyAnnote pipeline failed to initialize")

--- a/verbatim_diarization/pyannote/separate.py
+++ b/verbatim_diarization/pyannote/separate.py
@@ -15,7 +15,7 @@ from torch.serialization import add_safe_globals
 
 from verbatim.cache import ArtifactCache
 from verbatim.logging_utils import get_status_logger, status_enabled
-from verbatim.model_cache import get_pyannote_cache_dir, resolve_hf_file_path
+from verbatim.model_cache import get_pyannote_cache_dir, is_offline_mode, prefetch_hf_snapshot, resolve_hf_snapshot_path
 from verbatim_audio.audio import constrain_audio_range, wav_to_int16
 from verbatim_audio.sources.audiosource import AudioSource
 from verbatim_audio.sources.fileaudiosource import FileAudioSource
@@ -68,18 +68,26 @@ class PyannoteSpeakerSeparation(SeparationStrategy):
             safe_types.append(torch_version_mod.TorchVersion)  # type: ignore[attr-defined]
         add_safe_globals(safe_types)  # pyright: ignore[reportArgumentType]
 
-        pipeline_path = resolve_hf_file_path(
-            separation_model,
-            filename="config.yaml",
-            purpose="pyannote separation model",
-            cache_dir=get_pyannote_cache_dir(),
-            revision=PYANNOTE_SEPARATION_MODEL_REVISION,
-            token=self.huggingface_token or None,
-        )
+        cache_dir = get_pyannote_cache_dir()
+        if is_offline_mode():
+            pipeline_path = resolve_hf_snapshot_path(
+                separation_model,
+                purpose="pyannote separation model",
+                cache_dir=cache_dir,
+                revision=PYANNOTE_SEPARATION_MODEL_REVISION,
+                token=self.huggingface_token or None,
+            )
+        else:
+            pipeline_path = prefetch_hf_snapshot(
+                separation_model,
+                cache_dir=cache_dir,
+                revision=PYANNOTE_SEPARATION_MODEL_REVISION,
+                token=self.huggingface_token or None,
+            )
         self.pipeline = Pipeline.from_pretrained(
             pipeline_path,
             token=self.huggingface_token or None,
-            cache_dir=get_pyannote_cache_dir(),
+            cache_dir=cache_dir,
         )
         hyper_parameters = {
             "segmentation": {"min_duration_off": 0.0, "threshold": 0.82},


### PR DESCRIPTION
This pull request updates the way Hugging Face model files are resolved and loaded in the PyAnnote diarization and separation pipelines. The changes improve support for offline mode and ensure consistent cache handling. The most important changes are:

**Improved model file resolution and offline support:**

* Replaced the use of `resolve_hf_file_path` with new logic that checks if the environment is in offline mode, and then either resolves the snapshot path locally (`resolve_hf_snapshot_path`) or prefetches the snapshot (`prefetch_hf_snapshot`) for both diarization and separation pipelines. This ensures models can be loaded reliably in both online and offline environments. [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7L53-R72) [[2]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL71-R90)

**Consistent cache directory handling:**

* Now consistently uses a local variable `cache_dir` (from `get_pyannote_cache_dir()`) instead of calling the function multiple times, reducing redundancy and potential for errors. [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7L53-R72) [[2]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL71-R90)

**Updated imports to reflect new model cache utilities:**

* Updated import statements in both `diarize.py` and `separate.py` to include the new functions (`is_offline_mode`, `prefetch_hf_snapshot`, `resolve_hf_snapshot_path`) from `verbatim.model_cache`. [[1]](diffhunk://#diff-696b6bc3c5cee8c45e33ace2b309fb87e24ff0cbd13c665cc4d98e259416e9e7L18-R18) [[2]](diffhunk://#diff-eefbc57359b32c56b28ae335643c1f5a69698365aed4a7788d55b59be058dcbcL18-R18)…torage