### PR TITLE
Avoid failing on invalid audiofile metadata

### DIFF
--- a/tests/audio/test_audio.py
+++ b/tests/audio/test_audio.py
@@ -3,6 +3,7 @@ import math
 import unittest
 import wave
 from typing import cast
+from unittest.mock import patch
 
 import numpy as np
 
@@ -119,6 +120,21 @@ class TestAudioProcessing(unittest.TestCase):
 
         expected = np.array([-1.0, 0.0, 127.0 / 128.0], dtype=np.float32)
         np.testing.assert_array_almost_equal(output, expected, decimal=5)
+
+    def test_pyav_audio_source_ignores_invalid_metadata_bytes(self):
+        from verbatim_audio.sources.ffmpegfileaudiosource import PyAVAudioSource
+
+        def fake_open(*_args, **kwargs):
+            if kwargs.get("metadata_errors") != "ignore":
+                raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+            raise RuntimeError("stop after validating open options")
+
+        source = PyAVAudioSource(file_path="sample.wav", file_obj=io.BytesIO(b"RIFF"), preserve_channels=False)
+
+        with patch("verbatim_audio.sources.ffmpegfileaudiosource.av.open", side_effect=fake_open), self.assertRaisesRegex(
+            RuntimeError, "stop after validating open options"
+        ):
+            source.open()
 
     def test_samples_to_seconds(self):
         from verbatim_audio.audio import samples_to_seconds

--- a/verbatim_audio/sources/ffmpegfileaudiosource.py
+++ b/verbatim_audio/sources/ffmpegfileaudiosource.py
@@ -35,10 +35,10 @@ class PyAVAudioStream(AudioStream):
 
         if self.source.file_obj is not None:
             LOG.debug("Opening cached bytes with PyAV: %s", self.source.file_path)
-            self._container = av.open(self.source.file_obj, format=self.source.format_hint)
+            self._container = av.open(self.source.file_obj, format=self.source.format_hint, metadata_errors="ignore")
         else:
             LOG.debug("Opening file with PyAV: %s", self.source.file_path)
-            self._container = av.open(self.source.file_path)
+            self._container = av.open(self.source.file_path, metadata_errors="ignore")
 
         # Find the first audio stream (or choose a specific one if needed)
         audio_streams = [s for s in self._container.streams if s.type == "audio"]


### PR DESCRIPTION
This pull request improves the robustness of audio file handling by ensuring that invalid metadata bytes in audio files are ignored, preventing decoding errors. Additionally, it adds a test to verify this behavior.

**Audio file handling improvements:**

* Updated `av.open` calls in `ffmpegfileaudiosource.py` to include `metadata_errors="ignore"`, ensuring that files with invalid metadata bytes can still be opened without raising exceptions.

**Testing enhancements:**

* Added a new test `test_pyav_audio_source_ignores_invalid_metadata_bytes` in `test_audio.py` to verify that `PyAVAudioSource` correctly ignores invalid metadata bytes by passing the appropriate option to `av.open`.
* Imported `patch` from `unittest.mock` in `test_audio.py` to support mocking in the new test.